### PR TITLE
Use setuptools_scm for tag based versioning

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/pysindy/__init__.py
+++ b/pysindy/__init__.py
@@ -1,3 +1,11 @@
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    pass
+
+
 from pysindy.pysindy import SINDy
 from pysindy.differentiation import *
 from pysindy.optimizers import *

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,5 @@ pytest-lazy-fixture
 pytest-flake8
 flake8-builtins-unleashed
 codecov
-pre-commit
+setuptools_scm
+setuptools_scm_git_archive

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ with open(here / "README.rst", "r") as f:
 
 setup(
     name=NAME,
-    version="0.0.1",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     author=AUTHOR,


### PR DESCRIPTION
```
$ python -c "import pysindy; print(pysindy.__version__)"
0.10.1.dev127+gf84af35.d20200116
```

Is derived from the latest tag (`v0.10.0`) . You can read more about this here: https://github.com/pypa/setuptools_scm/