### PR TITLE
changed sindy equations method to correctly print equations

### DIFF
--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -205,13 +205,8 @@ class SINDy(BaseEstimator):
                 base_feature_names = [f + "[k]" for f in self.feature_names]
             else:
                 base_feature_names = self.feature_names
-            feature_names = (
-                self.model.estimators_[0]
-                .steps[0][1]
-                .get_feature_names(input_features=base_feature_names)
-            )
             return [
-                equation(est, input_features=feature_names, precision=precision)
+                equation(est, input_features=base_feature_names, precision=precision)
                 for est in self.model.estimators_
             ]
         else:


### PR DESCRIPTION
Features names were getting converted from ['x0','x1','x2'] to ['1', 'x0', 'x1', 'x2', 'x0^2', ...] twice, once in SINDy.equations() and once in utils.equation(). This was leading to incorrect printing of the equations. I removed the conversion happening in the SINDy.equations() method, so this conversion only happens in utils.equation().