### PR TITLE
Specify xml coverage file for codecov.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,13 +36,12 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Test with pytest
       run: |
-        py.test test --cov=pysindy
+        py.test test --cov=pysindy --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        name: codecov-umbrella
-        flags: unittests
+        file: ./coverage.xml
     - name: Execute feature notebook with papermill
       run: |
         pip install papermill


### PR DESCRIPTION
The previous setup caused the following error during the "Upload coverage to Codecov" action.

`No coverage report found.`

I've modified the configuration to more closely resemble [this example](https://github.com/codecov/codecov-action).