### PR TITLE
Fix handling of parameters in optimizer init functions.

### DIFF
--- a/pysindy/optimizers/base.py
+++ b/pysindy/optimizers/base.py
@@ -53,10 +53,22 @@ class BaseOptimizer(LinearRegression):
         unregularized least-squares fit.
     """
 
-    def __init__(self, normalize=False, fit_intercept=False, copy_X=True, unbias=True):
+    def __init__(
+        self,
+        max_iter=20,
+        normalize=False,
+        fit_intercept=False,
+        copy_X=True,
+        unbias=True,
+    ):
         super(BaseOptimizer, self).__init__(
             fit_intercept=fit_intercept, normalize=normalize, copy_X=copy_X
         )
+
+        if max_iter <= 0:
+            raise ValueError("max_iter must be positive")
+
+        self.max_iter = max_iter
         self.iters = 0
         self.coef_ = []
         self.ind_ = []

--- a/pysindy/optimizers/elastic_net.py
+++ b/pysindy/optimizers/elastic_net.py
@@ -30,6 +30,27 @@ class ElasticNet(BaseOptimizer):
         Optional keyword arguments to pass to the ElasticNet regression
         object.
 
+    fit_intercept : boolean, optional (default False)
+        Whether to calculate the intercept for this model. If set to false, no
+        intercept will be used in calculations.
+
+    normalize : boolean, optional (default False)
+        This parameter is ignored when fit_intercept is set to False. If True,
+        the regressors X will be normalized before regression by subtracting
+        the mean and dividing by the l2-norm.
+
+    copy_X : boolean, optional (default True)
+        If True, X will be copied; else, it may be overwritten.
+
+    unbias : boolean, optional (default True)
+        Whether to perform an extra step of unregularized linear regression to unbias
+        the coefficients for the identified support.
+        For example, if `STLSQ(alpha=0.1)` is used then the learned coefficients will
+        be biased toward 0 due to the L2 regularization.
+        Setting `unbias=True` will trigger an additional step wherein the nonzero
+        coefficients learned by the `STLSQ` object will be updated using an
+        unregularized least-squares fit.
+
     Attributes
     ----------
     coef_ : array, shape (n_features,) or (n_targets, n_features)
@@ -59,20 +80,31 @@ class ElasticNet(BaseOptimizer):
     """
 
     def __init__(
-        self, alpha=1.0, l1_ratio=0.5, max_iter=1000, elastic_net_kw={}, **kwargs
+        self,
+        alpha=1.0,
+        l1_ratio=0.5,
+        max_iter=1000,
+        elastic_net_kw={},
+        normalize=False,
+        fit_intercept=False,
+        copy_X=True,
+        unbias=True,
     ):
-        super(ElasticNet, self).__init__(**kwargs)
+        super(ElasticNet, self).__init__(
+            max_iter=max_iter,
+            normalize=normalize,
+            fit_intercept=fit_intercept,
+            copy_X=copy_X,
+            unbias=unbias,
+        )
 
         if alpha < 0:
             raise ValueError("alpha must be nonnegative")
         if l1_ratio < 0:
             raise ValueError("l1_ratio must be nonnegative")
-        if max_iter <= 0:
-            raise ValueError("max_iter must be positive")
 
         self.alpha = alpha
         self.l1_ratio = l1_ratio
-        self.max_iter = max_iter
         self.elastic_net_kw = elastic_net_kw
 
     def _reduce(self, x, y):

--- a/pysindy/optimizers/lasso.py
+++ b/pysindy/optimizers/lasso.py
@@ -22,6 +22,27 @@ class LASSO(BaseOptimizer):
         Optional keyword arguments to pass to the LASSO regression
         object.
 
+    fit_intercept : boolean, optional (default False)
+        Whether to calculate the intercept for this model. If set to false, no
+        intercept will be used in calculations.
+
+    normalize : boolean, optional (default False)
+        This parameter is ignored when fit_intercept is set to False. If True,
+        the regressors X will be normalized before regression by subtracting
+        the mean and dividing by the l2-norm.
+
+    copy_X : boolean, optional (default True)
+        If True, X will be copied; else, it may be overwritten.
+
+    unbias : boolean, optional (default True)
+        Whether to perform an extra step of unregularized linear regression to unbias
+        the coefficients for the identified support.
+        For example, if `STLSQ(alpha=0.1)` is used then the learned coefficients will
+        be biased toward 0 due to the L2 regularization.
+        Setting `unbias=True` will trigger an additional step wherein the nonzero
+        coefficients learned by the `STLSQ` object will be updated using an
+        unregularized least-squares fit.
+
     Attributes
     ----------
     coef_ : array, shape (n_features,) or (n_targets, n_features)
@@ -50,17 +71,29 @@ class LASSO(BaseOptimizer):
     x2' = 0.369 1^2 + 0.558 1 x0 + 0.150 1 x1 + 0.018 x0^2 + -0.133 x1^2
     """
 
-    def __init__(self, alpha=1.0, lasso_kw=None, max_iter=1000, **kwargs):
-        super(LASSO, self).__init__(**kwargs)
+    def __init__(
+        self,
+        alpha=1.0,
+        lasso_kw=None,
+        max_iter=1000,
+        normalize=False,
+        fit_intercept=False,
+        copy_X=True,
+        unbias=True,
+    ):
+        super(LASSO, self).__init__(
+            max_iter=max_iter,
+            normalize=normalize,
+            fit_intercept=fit_intercept,
+            copy_X=copy_X,
+            unbias=unbias,
+        )
 
         if alpha < 0:
             raise ValueError("alpha cannot be negative")
-        if max_iter <= 0:
-            raise ValueError("max_iter must be positive")
 
         self.lasso_kw = lasso_kw
         self.alpha = alpha
-        self.max_iter = max_iter
 
     def _reduce(self, x, y):
         """Performs the LASSO regression

--- a/pysindy/optimizers/stlsq.py
+++ b/pysindy/optimizers/stlsq.py
@@ -33,6 +33,27 @@ class STLSQ(BaseOptimizer):
     ridge_kw : dict, optional
         Optional keyword arguments to pass to the ridge regression.
 
+    fit_intercept : boolean, optional (default False)
+        Whether to calculate the intercept for this model. If set to false, no
+        intercept will be used in calculations.
+
+    normalize : boolean, optional (default False)
+        This parameter is ignored when fit_intercept is set to False. If True,
+        the regressors X will be normalized before regression by subtracting
+        the mean and dividing by the l2-norm.
+
+    copy_X : boolean, optional (default True)
+        If True, X will be copied; else, it may be overwritten.
+
+    unbias : boolean, optional (default True)
+        Whether to perform an extra step of unregularized linear regression to unbias
+        the coefficients for the identified support.
+        For example, if `STLSQ(alpha=0.1)` is used then the learned coefficients will
+        be biased toward 0 due to the L2 regularization.
+        Setting `unbias=True` will trigger an additional step wherein the nonzero
+        coefficients learned by the `STLSQ` object will be updated using an
+        unregularized least-squares fit.
+
     Attributes
     ----------
     coef_ : array, shape (n_features,) or (n_targets, n_features)
@@ -62,8 +83,24 @@ class STLSQ(BaseOptimizer):
     x2' = -2.666 x1 + 1.000 1 x0
     """
 
-    def __init__(self, threshold=0.1, alpha=0.0, max_iter=20, ridge_kw=None, **kwargs):
-        super(STLSQ, self).__init__(**kwargs)
+    def __init__(
+        self,
+        threshold=0.1,
+        alpha=0.0,
+        max_iter=20,
+        ridge_kw=None,
+        normalize=False,
+        fit_intercept=False,
+        copy_X=True,
+        unbias=True,
+    ):
+        super(STLSQ, self).__init__(
+            max_iter=max_iter,
+            normalize=normalize,
+            fit_intercept=fit_intercept,
+            copy_X=copy_X,
+            unbias=unbias,
+        )
 
         if threshold < 0:
             raise ValueError("threshold cannot be negative")
@@ -74,7 +111,6 @@ class STLSQ(BaseOptimizer):
 
         self.threshold = threshold
         self.alpha = alpha
-        self.max_iter = max_iter
         self.ridge_kw = ridge_kw
 
     def _sparse_coefficients(self, dim, ind, coef, threshold):

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -105,6 +105,6 @@ def test_unbias(data_derivative_1d):
 
     assert (
         norm(optimizer_biased.coef_ - optimizer_unbiased.coef_)
-        / norm(optimizer_unbiased.coef_)
+        / (norm(optimizer_unbiased.coef_) + 1e-5)
         > 1e-9
     )


### PR DESCRIPTION
Explicitly pass all parameters through optimizer `__init__` functions to base class `BaseOptimizer` `__init__` function. This fixes #37 . Move the `max_iter` parameter to `BaseOptimizer`.

I also updated the unit test for `unbias` to avoid division by zero.