### PR TITLE
Quiet mode

### DIFF
--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Sequence
 
 from numpy import isscalar
@@ -105,7 +106,7 @@ class SINDy(BaseEstimator):
         self.discrete_time = discrete_time
         self.n_jobs = n_jobs
 
-    def fit(self, x, t=1, x_dot=None, multiple_trajectories=False):
+    def fit(self, x, t=1, x_dot=None, multiple_trajectories=False, quiet=False):
         """
         Fit the SINDy model.
 
@@ -141,10 +142,16 @@ class SINDy(BaseEstimator):
             for each trajectory. If False, the training data must be a single
             array.
 
+        quiet: boolean, optional (default False)
+            Whether or not to suppress warnings during model fitting.
+
         Returns
         -------
         self: returns an instance of self
         """
+        if quiet:
+            warnings.filterwarnings("ignore")
+
         if multiple_trajectories:
             x, x_dot = self.process_multiple_trajectories(x, t, x_dot)
         else:

--- a/test/test_pysindy.py
+++ b/test/test_pysindy.py
@@ -482,3 +482,16 @@ def test_simulate_errors(data_lorenz):
     model = SINDy(discrete_time=True)
     with pytest.raises(ValueError):
         model.simulate(x[0], t=[1, 2])
+
+
+def test_fit_warn(data_lorenz):
+    x, t = data_lorenz
+    model = SINDy(optimizer=STLSQ(threshold=100))
+
+    with pytest.warns(UserWarning):
+        model.fit(x, t)
+
+    with pytest.warns(None) as warn_record:
+        model.fit(x, t, quiet=True)
+
+    assert warn_record is None

--- a/test/test_pysindy.py
+++ b/test/test_pysindy.py
@@ -14,6 +14,7 @@ pytest file_to_test.py
 """
 import numpy as np
 import pytest
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
 
@@ -484,11 +485,15 @@ def test_simulate_errors(data_lorenz):
         model.simulate(x[0], t=[1, 2])
 
 
-def test_fit_warn(data_lorenz):
+@pytest.mark.parametrize(
+    "params, warning",
+    [({"threshold": 100}, UserWarning), ({"max_iter": 1}, ConvergenceWarning)],
+)
+def test_fit_warn(data_lorenz, params, warning):
     x, t = data_lorenz
-    model = SINDy(optimizer=STLSQ(threshold=100))
+    model = SINDy(optimizer=STLSQ(**params))
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(warning):
         model.fit(x, t)
 
     with pytest.warns(None) as warn_record:

--- a/test/test_pysindy.py
+++ b/test/test_pysindy.py
@@ -494,4 +494,4 @@ def test_fit_warn(data_lorenz):
     with pytest.warns(None) as warn_record:
         model.fit(x, t, quiet=True)
 
-    assert warn_record is None
+    assert len(warn_record) == 0


### PR DESCRIPTION
Added a `quiet` option to suppress optimizer warnings when calling `SINDy.fit()`