### PR TITLE
Check optimizer attributes

### DIFF
--- a/pysindy/optimizers/sindy_optimizer.py
+++ b/pysindy/optimizers/sindy_optimizer.py
@@ -47,7 +47,7 @@ class SINDyOptimizer(BaseEstimator):
             if not supports_multiple_targets(self.optimizer):
                 self.optimizer = _MultiTargetLinearRegressor(self.optimizer)
         self.optimizer.fit(x, y)
-        if not hasattr(object, "coef_"):
+        if not hasattr(self.optimizer, "coef_"):
             raise AttributeError("optimizer has no attribute coef_")
         self.ind_ = np.abs(self.coef_) > 1e-14
 

--- a/pysindy/optimizers/sindy_optimizer.py
+++ b/pysindy/optimizers/sindy_optimizer.py
@@ -32,9 +32,11 @@ class SINDyOptimizer(BaseEstimator):
     """
 
     def __init__(self, optimizer, unbias=True):
-        if not hasattr(optimizer, 'fit') or not callable(getattr(optimizer, 'fit')):
+        if not hasattr(optimizer, "fit") or not callable(getattr(optimizer, "fit")):
             raise AttributeError("optimizer does not have a callable fit method")
-        if not hasattr(optimizer, 'predict') or not callable(getattr(optimizer, 'predict')):
+        if not hasattr(optimizer, "predict") or not callable(
+            getattr(optimizer, "predict")
+        ):
             raise AttributeError("optimizer does not have a callable predict method")
 
         self.optimizer = optimizer
@@ -45,7 +47,7 @@ class SINDyOptimizer(BaseEstimator):
             if not supports_multiple_targets(self.optimizer):
                 self.optimizer = _MultiTargetLinearRegressor(self.optimizer)
         self.optimizer.fit(x, y)
-        if not hasattr(object, 'coef_'):
+        if not hasattr(object, "coef_"):
             raise AttributeError("optimizer has no attribute coef_")
         self.ind_ = np.abs(self.coef_) > 1e-14
 
@@ -56,21 +58,18 @@ class SINDyOptimizer(BaseEstimator):
 
     def _unbias(self, x, y):
         coef = np.zeros((y.shape[1], x.shape[1]))
-        if hasattr(self.optimizer, 'fit_intercept'):
+        if hasattr(self.optimizer, "fit_intercept"):
             fit_intercept = self.optimizer.fit_intercept
         else:
             fit_intercept = False
-        if hasattr(self.optimizer, 'normalize'):
+        if hasattr(self.optimizer, "normalize"):
             normalize = self.optimizer.normalize
         else:
             normalize = False
         for i in range(self.ind_.shape[0]):
             if np.any(self.ind_[i]):
                 coef[i, self.ind_[i]] = (
-                    LinearRegression(
-                        fit_intercept=fit_intercept,
-                        normalize=normalize,
-                    )
+                    LinearRegression(fit_intercept=fit_intercept, normalize=normalize)
                     .fit(x[:, self.ind_[i]], y[:, i])
                     .coef_
                 )
@@ -95,7 +94,7 @@ class SINDyOptimizer(BaseEstimator):
 
     @property
     def intercept_(self):
-        if hasattr(self.optimizer, 'intercept_'):
+        if hasattr(self.optimizer, "intercept_"):
             return self.optimizer.intercept_
         else:
             return 0.0

--- a/pysindy/optimizers/sindy_optimizer.py
+++ b/pysindy/optimizers/sindy_optimizer.py
@@ -32,8 +32,11 @@ class SINDyOptimizer(BaseEstimator):
     """
 
     def __init__(self, optimizer, unbias=True):
-        # TODO: add a check that optimizer has the necessary attributes
-        # and methods
+        if not hasattr(optimizer, 'fit') or not callable(getattr(optimizer, 'fit')):
+            raise AttributeError("optimizer does not have a callable fit method")
+        if not hasattr(optimizer, 'predict') or not callable(getattr(optimizer, 'predict')):
+            raise AttributeError("optimizer does not have a callable predict method")
+
         self.optimizer = optimizer
         self.unbias = unbias
 
@@ -42,6 +45,8 @@ class SINDyOptimizer(BaseEstimator):
             if not supports_multiple_targets(self.optimizer):
                 self.optimizer = _MultiTargetLinearRegressor(self.optimizer)
         self.optimizer.fit(x, y)
+        if not hasattr(object, 'coef_'):
+            raise AttributeError("optimizer has no attribute coef_")
         self.ind_ = np.abs(self.coef_) > 1e-14
 
         if self.unbias:
@@ -51,12 +56,20 @@ class SINDyOptimizer(BaseEstimator):
 
     def _unbias(self, x, y):
         coef = np.zeros((y.shape[1], x.shape[1]))
+        if hasattr(self.optimizer, 'fit_intercept'):
+            fit_intercept = self.optimizer.fit_intercept
+        else:
+            fit_intercept = False
+        if hasattr(self.optimizer, 'normalize'):
+            normalize = self.optimizer.normalize
+        else:
+            normalize = False
         for i in range(self.ind_.shape[0]):
             if np.any(self.ind_[i]):
                 coef[i, self.ind_[i]] = (
                     LinearRegression(
-                        fit_intercept=self.optimizer.fit_intercept,
-                        normalize=self.optimizer.normalize,
+                        fit_intercept=fit_intercept,
+                        normalize=normalize,
                     )
                     .fit(x[:, self.ind_[i]], y[:, i])
                     .coef_
@@ -82,7 +95,10 @@ class SINDyOptimizer(BaseEstimator):
 
     @property
     def intercept_(self):
-        return self.optimizer.intercept_
+        if hasattr(self.optimizer, 'intercept_'):
+            return self.optimizer.intercept_
+        else:
+            return 0.0
 
     @property
     def complexity(self):

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -22,6 +22,26 @@ class DummyLinearModel(BaseEstimator):
         self.intercept_ = 0
         return self
 
+    def predict(self, x):
+        return x
+
+
+class DummyEmptyModel(BaseEstimator):
+    # Does not have fit or predict methods
+    def __init__(self):
+        self.fit_intercept = False
+        self.normalize = False
+
+
+class DummyModelNoCoef(BaseEstimator):
+    # Does not set the coef_ attribute
+    def fit(self, x, y):
+        self.intercept_ = 0
+        return self
+
+    def predict(self, x):
+        return x
+
 
 @pytest.mark.parametrize(
     "cls, support",
@@ -101,6 +121,18 @@ def test_bad_parameters(data_derivative_1d):
 
     with pytest.raises(ValueError):
         SR3(max_iter=0)
+
+
+def test_bad_optimizers(data_derivative_1d):
+    x, x_dot = data_derivative_1d
+    x = x.reshape(-1, 1)
+
+    with pytest.raises(AttributeError):
+        opt = SINDyOptimizer(DummyEmptyModel())
+
+    with pytest.raises(AttributeError):
+        opt = SINDyOptimizer(DummyModelNoCoef())
+        opt.fit(x, x_dot)
 
 
 # The different capitalizations are intentional;


### PR DESCRIPTION
Addresses #50 by having `SINDyOptimizer` perform checks for the various attributes and methods used in the optimizer that's passed in.

An `AttributeError` is now raised if the `fit` and `predict` methods and the `coef_` attribute are missing. If there is no `intercept_` attribute, the intercept is just set to `0.0`. If there are no `fit_intercept` and `normalize` attributes, these are just set to `False` for the unbiasing. If anyone has alternative suggestions for how these should be handled, feel free to discuss.