### PR TITLE
Add feature_overview.ipynb to documentation. Include binder link.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,3 +58,9 @@ html_show_sphinx = False
 html_show_copyright = True
 
 default_role = "any"
+
+# Added to support nbsphinx
+extensions.append("nbsphinx")
+extensions.append("sphinx.ext.mathjax")
+
+html_sourcelink_suffix = ""

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
    :caption: User Guide
 
    API Documentation <api/pysindy>
+   Feature overview <../example/feature_overview>
 
 .. toctree::
    :maxdepth: 1

--- a/example/feature_overview.ipynb
+++ b/example/feature_overview.ipynb
@@ -2,11 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-09T00:05:47.829870Z",
+     "start_time": "2020-03-09T00:05:47.821638Z"
+    }
+   },
+   "source": [
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dynamicslab/pysindy/v0.13.0?filepath=example%2Ffeature_overview.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# PySINDy Package Feature Overview\n",
     "\n",
-    "This notebook provides a simple overview of the basic functionality of the PySINDy software package. In addition to demonstrating the basic usage for fitting a SINDy model, we demonstrate several means of customizing the SINDy fitting procedure. These include different forms of input data, different optimization methods, different differentiation methods, and custom feature libraries."
+    "This notebook provides a simple overview of the basic functionality of the PySINDy software package. In addition to demonstrating the basic usage for fitting a SINDy model, we demonstrate several means of customizing the SINDy fitting procedure. These include different forms of input data, different optimization methods, different differentiation methods, and custom feature libraries.\n",
+    "\n",
+    "An interactive version of this notebook is available on binder."
    ]
   },
   {
@@ -993,7 +1007,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ sphinxcontrib-apidoc
 sphinx_rtd_theme
 pre-commit
 hypothesis
+nbsphinx


### PR DESCRIPTION
Related to #46 .
Include `example/feature_overview.ipynb` in Sphinx documentation via nbsphinx.

I've also added a binder link for `feature_overview.ipynb` so that users can play around with the notebook without downloading the package and all its dependencies.