### PR TITLE
Fix math formatting.

### DIFF
--- a/examples/2_original_paper.ipynb
+++ b/examples/2_original_paper.ipynb
@@ -436,7 +436,8 @@
     "\t\\dot z &= xy - \\beta z,\n",
     "\\end{aligned}\n",
     "$$\n",
-    "with $\\sigma=10$, $\\rho=28$, and $\\beta=\\tfrac83$ for this example. We generate our training data starting from the initial condition $(-8, 8, 27)$. Note that for this example we also collect measurements of derivatives of state variables, $(\\dot x, \\dot y, \\dot z)$."
+    "\n",
+    "with $\\sigma=10$, $\\rho=28$, and $\\beta=\\tfrac{8}{3}$ for this example. We generate our training data starting from the initial condition $(-8, 8, 27)$. Note that for this example we also collect measurements of derivatives of state variables, $(\\dot x, \\dot y, \\dot z)$."
    ]
   },
   {


### PR DESCRIPTION
There was a problem with how a math equation was formatted in original paper notebook. The equation was properly displayed in my local notebook, but not on Github nor in the sphinx documentation.

I would have just pushed directly to master, but I wanted to make sure Github rendered the equation properly.