### PR TITLE
Sindyc

### DIFF
--- a/pysindy/__init__.py
+++ b/pysindy/__init__.py
@@ -8,7 +8,6 @@ except DistributionNotFound:
 
 
 from .pysindy import SINDy
-from .pysindy import SINDyC
 from pysindy.differentiation import *
 from pysindy.optimizers import *
 from pysindy.feature_library import *

--- a/pysindy/__init__.py
+++ b/pysindy/__init__.py
@@ -7,7 +7,8 @@ except DistributionNotFound:
     pass
 
 
-from pysindy.pysindy import SINDy
+from .pysindy import SINDy
+from .pysindy import SINDyC
 from pysindy.differentiation import *
 from pysindy.optimizers import *
 from pysindy.feature_library import *

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -91,6 +91,37 @@ class SINDy(BaseEstimator):
            [ 0.        ,  0.        ,  0.        ]])
     >>> model.score(x, t=t[1]-t[0])
     0.999999985520653
+
+    >>> import numpy as np
+    >>> from scipy.integrate import odeint
+    >>> from pysindy import SINDy
+    >>> u = lambda t : np.sin(2 * t)
+    >>> lorenz_c = lambda z,t : [
+                10 * (z[1] - z[0]) + u(t) ** 2,
+                z[0] * (28 - z[2]) - z[1],
+                z[0] * z[1] - 8 / 3 * z[2],
+        ]
+    >>> t = np.arange(0,2,0.002)
+    >>> x = odeint(lorenz_c, [-8,8,27], t)
+    >>> u_eval = u(t)
+    >>> model = SINDy()
+    >>> model.fit(x, u_eval, t=t[1]-t[0])
+    >>> model.print()
+    x0' = -10.000 x0 + 10.000 x1 + 1.001 u0^2
+    x1' = 27.994 x0 + -0.999 x1 + -1.000 x0 x2
+    x2' = -2.666 x2 + 1.000 x0 x1
+    >>> model.coefficients()
+    array([[ 0.        , -9.99969851,  9.99958359,  0.        ,  0.        ,
+             0.        ,  0.        ,  0.        ,  0.        ,  0.        ,
+             0.        ,  0.        ,  0.        ,  0.        ,  1.00120331],
+           [ 0.        , 27.9935177 , -0.99906375,  0.        ,  0.        ,
+             0.        ,  0.        , -0.99980455,  0.        ,  0.        ,
+             0.        ,  0.        ,  0.        ,  0.        ,  0.        ],
+           [ 0.        ,  0.        ,  0.        , -2.666437  ,  0.        ,
+             0.        ,  0.99990137,  0.        ,  0.        ,  0.        ,
+             0.        ,  0.        ,  0.        ,  0.        ,  0.        ]])
+    >>> model.score(x, u_eval, t=t[1]-t[0])
+    0.9999999855414495
     """
 
     def __init__(
@@ -116,7 +147,14 @@ class SINDy(BaseEstimator):
         self.n_jobs = n_jobs
 
     def fit(
-        self, x, t=1, x_dot=None, multiple_trajectories=False, unbias=True, quiet=False,
+        self,
+        x,
+        t=1,
+        x_dot=None,
+        u=None,
+        multiple_trajectories=False,
+        unbias=True,
+        quiet=False,
     ):
         """
         Fit the SINDy model.
@@ -147,6 +185,15 @@ class SINDy(BaseEstimator):
             provided, it must match the shape of the training data and these
             values will be used as the time derivatives.
 
+        u: array-like or list of array-like, shape (n_samples, n_control_features), \
+                optional (default None)
+            Control variables/inputs. Include this variable to use sparse
+            identification for nonlinear dynamical systems for control (SINDYc).
+            If training data contains multiple trajectories (i.e. if x is a list of
+            array-like), then u should be a list containing control variable data
+            for each trajectory. Individual trajectories may contain different
+            numbers of samples.
+
         multiple_trajectories: boolean, optional, (default False)
             Whether or not the training data includes multiple trajectories. If
             True, the training data must be a list of arrays containing data
@@ -171,6 +218,18 @@ class SINDy(BaseEstimator):
         -------
         self: returns an instance of self
         """
+        if u is None:
+            self.n_control_features_ = 0
+        else:
+            trim_last_point = self.discrete_time and (x_dot is None)
+            u = validate_control_variables(
+                x,
+                u,
+                multiple_trajectories=multiple_trajectories,
+                trim_last_point=trim_last_point,
+            )
+            self.n_control_features_ = u.shape[1]
+
         if multiple_trajectories:
             x, x_dot = self.process_multiple_trajectories(x, t, x_dot)
         else:
@@ -187,6 +246,10 @@ class SINDy(BaseEstimator):
                     x_dot = self.differentiation_method(x, t)
                 else:
                     x_dot = validate_input(x_dot, t)
+
+        # Append control variables
+        if self.n_control_features_ > 0:
+            x = concatenate((x, u), axis=1)
 
         # Drop rows where derivative isn't known
         x, x_dot = drop_nan_rows(x, x_dot)
@@ -208,13 +271,15 @@ class SINDy(BaseEstimator):
 
         if self.feature_names is None:
             feature_names = []
-            for i in range(self.n_input_features_):
+            for i in range(self.n_input_features_ - self.n_control_features_):
                 feature_names.append("x" + str(i))
+            for i in range(self.n_control_features_):
+                feature_names.append("u" + str(i))
             self.feature_names = feature_names
 
         return self
 
-    def predict(self, x, multiple_trajectories=False):
+    def predict(self, x, u=None, multiple_trajectories=False):
         """
         Predict the time derivatives using the SINDy model.
 
@@ -222,6 +287,12 @@ class SINDy(BaseEstimator):
         ----------
         x: array-like or list of array-like, shape (n_samples, n_input_features)
             Samples.
+
+        u: array-like or list of array-like, shape(n_samples, n_control_features), \
+                (default None)
+            Control variables. If `multiple_trajectories=True` then u
+            must be a list of control variable data from each trajectory. If the
+            model was fit with control variables then u is not optional.
 
         multiple_trajectories: boolean, optional (default False)
             If True, x contains multiple trajectories and must be a list of
@@ -233,12 +304,31 @@ class SINDy(BaseEstimator):
             Predicted time derivatives
         """
         check_is_fitted(self, "model")
-        if multiple_trajectories:
-            x = [validate_input(xi) for xi in x]
-            return [self.model.predict(xi) for xi in x]
+        if u is None:
+            if self.n_control_features_ > 0:
+                raise TypeError(
+                    "Model was fit using control variables, so u is required"
+                )
+            if multiple_trajectories:
+                x = [validate_input(xi) for xi in x]
+                return [self.model.predict(xi) for xi in x]
+            else:
+                x = validate_input(x)
+                return self.model.predict(x)
         else:
-            x = validate_input(x)
-            return self.model.predict(x)
+            if multiple_trajectories:
+                x = [validate_input(xi) for xi in x]
+                u = validate_control_variables(
+                    x, u, multiple_trajectories=True, return_array=False
+                )
+                return [
+                    self.model.predict(concatenate((xi, ui), axis=1))
+                    for xi, ui in zip(x, u)
+                ]
+            else:
+                x = validate_input(x)
+                u = validate_control_variables(x, u)
+                return self.model.predict(concatenate((x, u), axis=1))
 
     def equations(self, precision=3):
         """
@@ -289,6 +379,7 @@ class SINDy(BaseEstimator):
         x,
         t=1,
         x_dot=None,
+        u=None,
         multiple_trajectories=False,
         metric=r2_score,
         **metric_kws
@@ -308,11 +399,17 @@ class SINDy(BaseEstimator):
             provided.
 
         x_dot: array-like or list of array-like, shape (n_samples, n_input_features), \
-                optional
+                optional (default None)
             Optional pre-computed derivatives of the samples. If provided,
             these values will be used to compute the score. If not provided,
             the time derivatives of the training data will be computed using
             the specified differentiation method.
+
+        u: array-like or list of array-like, shape(n_samples, n_control_features), \
+                optional (default None)
+            Control variables. If `multiple_trajectories=True` then u
+            must be a list of control variable data from each trajectory.
+            If the model was fit with control variables then u is not optional.
 
         multiple_trajectories: boolean, optional (default False)
             If True, x contains multiple trajectories and must be a list of
@@ -330,6 +427,20 @@ class SINDy(BaseEstimator):
         score: float
             Metric function value for the model prediction of x_dot.
         """
+        if u is None:
+            if self.n_control_features_ > 0:
+                raise TypeError(
+                    "Model was fit using control variables, so u is required"
+                )
+        else:
+            trim_last_point = self.discrete_time and (x_dot is None)
+            u = validate_control_variables(
+                x,
+                u,
+                multiple_trajectories=multiple_trajectories,
+                trim_last_point=trim_last_point,
+            )
+
         if multiple_trajectories:
             x, x_dot = self.process_multiple_trajectories(
                 x, t, x_dot, return_array=True
@@ -345,6 +456,10 @@ class SINDy(BaseEstimator):
 
         if ndim(x_dot) == 1:
             x_dot = x_dot.reshape(-1, 1)
+
+        # Append control variables
+        if u is not None:
+            x = concatenate((x, u), axis=1)
 
         # Drop rows where derivative isn't known (usually endpoints)
         x, x_dot = drop_nan_rows(x, x_dot)
@@ -447,7 +562,9 @@ class SINDy(BaseEstimator):
             input_features=self.feature_names
         )
 
-    def simulate(self, x0, t, integrator=odeint, stop_condition=None, **integrator_kws):
+    def simulate(
+        self, x0, t, u=None, integrator=odeint, stop_condition=None, **integrator_kws
+    ):
         """
         Simulate the SINDy model forward in time.
 
@@ -461,388 +578,8 @@ class SINDy(BaseEstimator):
             points at which to simulate. If the model is in discrete time,
             t must be an integer indicating how many steps to predict.
 
-        integrator: function object, optional
-            Function to use to integrate the system. Default is scipy's odeint.
-
-        stop_condition: function object, optional
-            If model is in discrete time, optional function that gives a
-            stopping condition for stepping the simulation forward.
-
-        integrator_kws: dict, optional
-            Optional keyword arguments to pass to the integrator
-
-        Returns
-        -------
-        x: numpy array, shape (n_samples, n_features)
-            Simulation results
-        """
-
-        if self.discrete_time:
-            if not isinstance(t, int):
-                raise ValueError(
-                    "For discrete time model, t must be an integer (indicating"
-                    "the number of steps to predict)"
-                )
-
-            x = zeros((t, self.n_input_features_))
-            x[0] = x0
-            for i in range(1, t):
-                x[i] = self.predict(x[i - 1 : i])
-                if stop_condition is not None and stop_condition(x[i]):
-                    return x[: i + 1]
-            return x
-        else:
-            if isscalar(t):
-                raise ValueError(
-                    "For continuous time model, t must be an array of time"
-                    " points at which to simulate"
-                )
-
-            def rhs(x, t):
-                return self.predict(x[newaxis, :])[0]
-
-            return integrator(rhs, x0, t, **integrator_kws)
-
-    @property
-    def complexity(self):
-        return self.model.steps[-1][1].complexity
-
-
-class SINDyC(SINDy):
-    """
-    SINDyC (SINDy with control) model object.
-
-    Parameters
-    ----------
-    optimizer : optimizer object, optional
-        Optimization method used to fit the SINDy model. This must be an object
-        that extends the sindy.optimizers.BaseOptimizer class. Default is
-        sequentially thresholded least squares with a threshold of 0.1.
-
-    feature_library : feature library object, optional
-        Default is polynomial features of degree 2.
-
-    differentiation_method : differentiation object, optional
-        Method for differentiating the data. This must be an object that
-        extends the sindy.differentiation_methods.BaseDifferentiation class.
-        Default is centered difference.
-
-    feature_names : list of string, length n_input_features, optional
-        Names for the input features. If None, will use ['x0','x1',...].
-
-    discrete_time : boolean, optional (default False)
-        If True, dynamical system is treated as a map. Rather than predicting
-        derivatives, the right hand side functions step the system forward by
-        one time step. If False, dynamical system is assumed to be a flow
-        (right hand side functions predict continuous time derivatives).
-
-    n_jobs : int, optional (default 1)
-        The number of parallel jobs to use when fitting, predicting with, and
-        scoring the model.
-
-    Attributes
-    ----------
-    model : sklearn.multioutput.MultiOutputRegressor object
-        The fitted SINDyC model.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from scipy.integrate import odeint
-    >>> from pysindy import SINDyC
-    >>> u = lambda t : np.sin(2 * t)
-    >>> lorenz_c = lambda z,t : [
-                10 * (z[1] - z[0]) + u(t) ** 2,
-                z[0] * (28 - z[2]) - z[1],
-                z[0] * z[1] - 8 / 3 * z[2],
-        ]
-    >>> t = np.arange(0,2,0.002)
-    >>> x = odeint(lorenz_c, [-8,8,27], t)
-    >>> u_eval = u(t)
-    >>> model = SINDyC()
-    >>> model.fit(x, u_eval, t=t[1]-t[0])
-    SINDyC()
-    >>> model.print()
-    x0' = -10.000 x0 + 10.000 x1 + 1.001 u0^2
-    x1' = 27.994 x0 + -0.999 x1 + -1.000 x0 x2
-    x2' = -2.666 x2 + 1.000 x0 x1
-    >>> model.coefficients()
-    array([[ 0.        , -9.99969851,  9.99958359,  0.        ,  0.        ,
-             0.        ,  0.        ,  0.        ,  0.        ,  0.        ,
-             0.        ,  0.        ,  0.        ,  0.        ,  1.00120331],
-           [ 0.        , 27.9935177 , -0.99906375,  0.        ,  0.        ,
-             0.        ,  0.        , -0.99980455,  0.        ,  0.        ,
-             0.        ,  0.        ,  0.        ,  0.        ,  0.        ],
-           [ 0.        ,  0.        ,  0.        , -2.666437  ,  0.        ,
-             0.        ,  0.99990137,  0.        ,  0.        ,  0.        ,
-             0.        ,  0.        ,  0.        ,  0.        ,  0.        ]])
-    >>> model.score(x, u_eval, t=t[1]-t[0])
-    0.9999999855414495
-    """
-
-    def __init__(self, **kwargs):
-        super(SINDyC, self).__init__(**kwargs)
-
-    def fit(
-        self,
-        x,
-        u,
-        t=1,
-        x_dot=None,
-        multiple_trajectories=False,
-        unbias=True,
-        quiet=False,
-    ):
-        """
-        Fit the SINDy model.
-
-        Parameters
-        ----------
-        x: array-like or list of array-like, shape (n_samples, n_input_features)
-            Training data. If training data contains multiple trajectories,
-            x should be a list containing data for each trajectory. Individual
-            trajectories may contain different numbers of samples.
-
-        u: array-like or list of array-like, shape (n_samples, n_control_features)
-            Control variables. If training data contains multiple trajectories
-            (i.e. if x is a list of array-like), then u should be a
-            list containing control variable data for each trajectory. Individual
-            trajectories may contain different numbers of samples
-
-        t: float, numpy array of shape [n_samples], or list of numpy arrays, optional \
-                (default 1)
-            If t is a float, it specifies the timestep between each sample.
-            If array-like, it specifies the time at which each sample was
-            collected.
-            In this case the values in t must be strictly increasing.
-            In the case of multi-trajectory training data, t may also be a list
-            of arrays containing the collection times for each individual
-            trajectory.
-            Default value is a timestep of 1 between samples.
-
-        x_dot: array-like or list of array-like, shape (n_samples, n_input_features), \
-                optional (default None)
-            Optional pre-computed derivatives of the training data. If not
-            provided, the time derivatives of the training data will be
-            computed using the specified differentiation method. If x_dot is
-            provided, it must match the shape of the training data and these
-            values will be used as the time derivatives.
-
-        multiple_trajectories: boolean, optional, (default False)
-            Whether or not the training data includes multiple trajectories. If
-            True, the training data must be a list of arrays containing data
-            for each trajectory. If False, the training data must be a single
-            array.
-
-        unbias: boolean, optional (default True)
-            Whether to perform an extra step of unregularized linear regression to
-            unbias the coefficients for the identified support.
-            If the optimizer (`SINDy.optimizer`) applies any type of regularization,
-            that regularization may bias coefficients toward particular values,
-            improving the conditioning of the problem but harming the quality of the
-            fit. Setting `unbias=True` enables an extra step wherein unregularized
-            linear regression is applied, but only for the coefficients in the support
-            identified by the optimizer. This helps to remove the bias introduced by
-            regularization.
-
-        quiet: boolean, optional (default False)
-            Whether or not to suppress warnings during model fitting.
-
-        Returns
-        -------
-        self: returns an instance of self
-        """
-        trim_last_point = self.discrete_time and (x_dot is None)
-        u = validate_control_variables(
-            x,
-            u,
-            multiple_trajectories=multiple_trajectories,
-            trim_last_point=trim_last_point,
-        )
-        self.n_control_features_ = u.shape[1]
-
-        if multiple_trajectories:
-            x, x_dot = self.process_multiple_trajectories(x, t, x_dot)
-        else:
-            x = validate_input(x, t)
-
-            if self.discrete_time:
-                if x_dot is None:
-                    x_dot = x[1:]
-                    x = x[:-1]
-                else:
-                    x_dot = validate_input(x_dot)
-            else:
-                if x_dot is None:
-                    x_dot = self.differentiation_method(x, t)
-                else:
-                    x_dot = validate_input(x_dot, t)
-
-        # Append control variables
-        x = concatenate((x, u), axis=1)
-
-        # Drop rows where derivative isn't known
-        x, x_dot = drop_nan_rows(x, x_dot)
-
-        optimizer = SINDyOptimizer(self.optimizer, unbias=unbias)
-        steps = [("features", self.feature_library), ("model", optimizer)]
-        self.model = Pipeline(steps)
-
-        action = "ignore" if quiet else "default"
-        with warnings.catch_warnings():
-            warnings.filterwarnings(action, category=ConvergenceWarning)
-            warnings.filterwarnings(action, category=LinAlgWarning)
-            warnings.filterwarnings(action, category=UserWarning)
-
-            self.model.fit(x, x_dot)
-
-        self.n_input_features_ = self.model.steps[0][1].n_input_features_
-        self.n_output_features_ = self.model.steps[0][1].n_output_features_
-
-        if self.feature_names is None:
-            feature_names = []
-            for i in range(self.n_input_features_ - self.n_control_features_):
-                feature_names.append("x" + str(i))
-            for i in range(self.n_control_features_):
-                feature_names.append("u" + str(i))
-            self.feature_names = feature_names
-
-        return self
-
-    def predict(self, x, u, multiple_trajectories=False):
-        """
-        Predict the time derivatives using the SINDyC model.
-
-        Parameters
-        ----------
-        x: array-like or list of array-like, shape (n_samples, n_input_features)
-            Samples.
-
-        u: array-like or list of array-like, shape(n_samples, n_control_features)
-            Control variables. If `multiple_trajectories=True` then u
-            must be a list of control variable data from each trajectory.
-
-        multiple_trajectories: boolean, optional (default False)
-            If True, x contains multiple trajectories and must be a list of
-            data from each trajectory. If False, x is a single trajectory.
-
-        Returns
-        -------
-        x_dot: array-like or list of array-like, shape (n_samples, n_input_features)
-            Predicted time derivatives
-        """
-        check_is_fitted(self, "model")
-        if multiple_trajectories:
-            x = [validate_input(xi) for xi in x]
-            u = validate_control_variables(
-                x, u, multiple_trajectories=True, return_array=False
-            )
-            return [
-                self.model.predict(concatenate((xi, ui), axis=1))
-                for xi, ui in zip(x, u)
-            ]
-        else:
-            x = validate_input(x)
-            u = validate_control_variables(x, u)
-            return self.model.predict(concatenate((x, u), axis=1))
-
-    def score(
-        self,
-        x,
-        u,
-        t=1,
-        x_dot=None,
-        multiple_trajectories=False,
-        metric=r2_score,
-        **metric_kws
-    ):
-        """
-        Returns a score for the time derivative prediction.
-
-        Parameters
-        ----------
-        x: array-like or list of array-like, shape (n_samples, n_input_features)
-            Samples
-
-        u: array-like or list of array-like, shape(n_samples, n_control_features)
-            Control variables. If `multiple_trajectories=True` then u
-            must be a list of control variable data from each trajectory.
-
-        t: float, numpy array of shape [n_samples], or list of numpy arrays, optional \
-                (default 1)
-            Time step between samples or array of collection times. Optional,
-            used to compute the time derivatives of the samples if x_dot is not
-            provided.
-
-        x_dot: array-like or list of array-like, shape (n_samples, n_input_features), \
-                optional
-            Optional pre-computed derivatives of the samples. If provided,
-            these values will be used to compute the score. If not provided,
-            the time derivatives of the training data will be computed using
-            the specified differentiation method.
-
-        multiple_trajectories: boolean, optional (default False)
-            If True, x contains multiple trajectories and must be a list of
-            data from each trajectory. If False, x is a single trajectory.
-
-        metric: metric function, optional
-            Metric function with which to score the prediction. Default is the
-            coefficient of determination R^2.
-
-        metric_kws: dict, optional
-            Optional keyword arguments to pass to the metric function.
-
-        Returns
-        -------
-        score: float
-            Metric function value for the model prediction of x_dot.
-        """
-        trim_last_point = self.discrete_time and (x_dot is None)
-        u = validate_control_variables(
-            x,
-            u,
-            multiple_trajectories=multiple_trajectories,
-            trim_last_point=trim_last_point,
-        )
-        if multiple_trajectories:
-            x, x_dot = self.process_multiple_trajectories(
-                x, t, x_dot, return_array=True
-            )
-        else:
-            x = validate_input(x, t)
-            if x_dot is None:
-                if self.discrete_time:
-                    x_dot = x[1:]
-                    x = x[:-1]
-                else:
-                    x_dot = self.differentiation_method(x, t)
-
-        if ndim(x_dot) == 1:
-            x_dot = x_dot.reshape(-1, 1)
-
-        # Append control variables
-        x = concatenate((x, u), axis=1)
-
-        # Drop rows where derivative isn't known (usually endpoints)
-        x, x_dot = drop_nan_rows(x, x_dot)
-
-        # Separate control variables from system variables to conform
-        # to the predict function's call signature
-        x_dot_predict = self.model.predict(x)
-        return metric(x_dot_predict, x_dot, **metric_kws)
-
-    def simulate(
-        self, x0, u, t, integrator=odeint, stop_condition=None, **integrator_kws
-    ):
-        """
-        Simulate the SINDyC model forward in time.
-
-        Parameters
-        ----------
-        x0: numpy array, size [n_features]
-            Initial condition from which to simulate.
-
-        u: function from R^1 to R^{n_control_features} or list/array
+        u: function from R^1 to R^{n_control_features} or list/array, optional \
+            (default None)
             Control input function.
             If the model is continuous time, i.e. `self.discrete_time == False`,
             this function should take in a time and output the values of each of
@@ -851,11 +588,6 @@ class SINDyC(SINDy):
             u should be a list (with `len(u) == t`) or array (with `u.shape[0] == 1`)
             giving the control inputs at each step.
 
-        t: int or numpy array of size [n_samples]
-            If the model is in continuous time, t must be an array of time
-            points at which to simulate. If the model is in discrete time,
-            t must be an integer indicating how many steps to predict.
-
         integrator: function object, optional
             Function to use to integrate the system. Default is scipy's odeint.
 
@@ -871,6 +603,9 @@ class SINDyC(SINDy):
         x: numpy array, shape (n_samples, n_features)
             Simulation results
         """
+        check_is_fitted(self, "model")
+        if u is None and self.n_control_features_ > 0:
+            raise TypeError("Model was fit using control variables, so u is required")
 
         if self.discrete_time:
             if not isinstance(t, int):
@@ -878,12 +613,30 @@ class SINDyC(SINDy):
                     "For discrete time model, t must be an integer (indicating"
                     "the number of steps to predict)"
                 )
+
+            if stop_condition is not None:
+
+                def check_stop_condition(xi):
+                    return stop_condition(xi)
+
+            else:
+
+                def check_stop_condition(xi):
+                    pass
+
             x = zeros((t, self.n_input_features_ - self.n_control_features_))
             x[0] = x0
-            for i in range(1, t):
-                x[i] = self.predict(x[i - 1 : i], u[i - 1])
-                if stop_condition is not None and stop_condition(x[i]):
-                    return x[: i + 1]
+
+            if u is None:
+                for i in range(1, t):
+                    x[i] = self.predict(x[i - 1 : i])
+                    if check_stop_condition(x[i]):
+                        return x[: i + 1]
+            else:
+                for i in range(1, t):
+                    x[i] = self.predict(x[i - 1 : i], u=u[i - 1])
+                    if check_stop_condition(x[i]):
+                        return x[: i + 1]
             return x
         else:
             if isscalar(t):
@@ -892,7 +645,18 @@ class SINDyC(SINDy):
                     " points at which to simulate"
                 )
 
-            def rhs(x, t):
-                return self.predict(x[newaxis, :], u(t))[0]
+            if u is None:
+
+                def rhs(x, t):
+                    return self.predict(x[newaxis, :])[0]
+
+            else:
+
+                def rhs(x, t):
+                    return self.predict(x[newaxis, :], u(t))[0]
 
             return integrator(rhs, x0, t, **integrator_kws)
+
+    @property
+    def complexity(self):
+        return self.model.steps[-1][1].complexity

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -796,7 +796,5 @@ class SINDyC(SINDy):
 
         # Separate control variables from system variables to conform
         # to the predict function's call signature
-        x_dot_predict = self.model.predict(
-            x[:, : -self.n_control_features_], x[:, -self.n_control_features_ :]
-        )
+        x_dot_predict = self.model.predict(x)
         return metric(x_dot_predict, x_dot, **metric_kws)

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -543,7 +543,41 @@ class SINDyC(SINDy):
     Attributes
     ----------
     model : sklearn.multioutput.MultiOutputRegressor object
-        The fitted SINDy model.
+        The fitted SINDyC model.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.integrate import odeint
+    >>> from pysindy import SINDyC
+    >>> u = lambda t : np.sin(2 * t)
+    >>> lorenz_c = lambda z,t : [
+                10 * (z[1] - z[0]) + u(t) ** 2,
+                z[0] * (28 - z[2]) - z[1],
+                z[0] * z[1] - 8 / 3 * z[2],
+        ]
+    >>> t = np.arange(0,2,0.002)
+    >>> x = odeint(lorenz_c, [-8,8,27], t)
+    >>> u_eval = u(t)
+    >>> model = SINDyC()
+    >>> model.fit(x, u_eval, t=t[1]-t[0])
+    SINDyC()
+    >>> model.print()
+    x0' = -10.000 x0 + 10.000 x1 + 1.001 u0^2
+    x1' = 27.994 x0 + -0.999 x1 + -1.000 x0 x2
+    x2' = -2.666 x2 + 1.000 x0 x1
+    >>> model.coefficients()
+    array([[ 0.        , -9.99969851,  9.99958359,  0.        ,  0.        ,
+             0.        ,  0.        ,  0.        ,  0.        ,  0.        ,
+             0.        ,  0.        ,  0.        ,  0.        ,  1.00120331],
+           [ 0.        , 27.9935177 , -0.99906375,  0.        ,  0.        ,
+             0.        ,  0.        , -0.99980455,  0.        ,  0.        ,
+             0.        ,  0.        ,  0.        ,  0.        ,  0.        ],
+           [ 0.        ,  0.        ,  0.        , -2.666437  ,  0.        ,
+             0.        ,  0.99990137,  0.        ,  0.        ,  0.        ,
+             0.        ,  0.        ,  0.        ,  0.        ,  0.        ]])
+    >>> model.score(x, u_eval, t=t[1]-t[0])
+    0.9999999855414495
     """
 
     def __init__(self, **kwargs):

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -304,10 +304,15 @@ class SINDy(BaseEstimator):
             Predicted time derivatives
         """
         check_is_fitted(self, "model")
-        if u is None:
+        if u is None or self.n_control_features_ == 0:
             if self.n_control_features_ > 0:
                 raise TypeError(
                     "Model was fit using control variables, so u is required"
+                )
+            elif u is not None:
+                warnings.warn(
+                    "Control variables u were ignored because control variables were"
+                    " not used when the model was fit"
                 )
             if multiple_trajectories:
                 x = [validate_input(xi) for xi in x]
@@ -427,10 +432,15 @@ class SINDy(BaseEstimator):
         score: float
             Metric function value for the model prediction of x_dot.
         """
-        if u is None:
+        if u is None or self.n_control_features_ == 0:
             if self.n_control_features_ > 0:
                 raise TypeError(
                     "Model was fit using control variables, so u is required"
+                )
+            elif u is not None:
+                warnings.warn(
+                    "Control variables u were ignored because control variables were"
+                    " not used when the model was fit"
                 )
         else:
             trim_last_point = self.discrete_time and (x_dot is None)
@@ -458,7 +468,7 @@ class SINDy(BaseEstimator):
             x_dot = x_dot.reshape(-1, 1)
 
         # Append control variables
-        if u is not None:
+        if u is not None and self.n_control_features_ > 0:
             x = concatenate((x, u), axis=1)
 
         # Drop rows where derivative isn't known (usually endpoints)
@@ -627,7 +637,12 @@ class SINDy(BaseEstimator):
             x = zeros((t, self.n_input_features_ - self.n_control_features_))
             x[0] = x0
 
-            if u is None:
+            if u is None or self.n_control_features_ == 0:
+                if u is not None:
+                    warnings.warn(
+                        "Control variables u were ignored because control variables"
+                        " were not used when the model was fit"
+                    )
                 for i in range(1, t):
                     x[i] = self.predict(x[i - 1 : i])
                     if check_stop_condition(x[i]):
@@ -645,7 +660,12 @@ class SINDy(BaseEstimator):
                     " points at which to simulate"
                 )
 
-            if u is None:
+            if u is None or self.n_control_features_ == 0:
+                if u is not None:
+                    warnings.warn(
+                        "Control variables u were ignored because control variables"
+                        " were not used when the model was fit"
+                    )
 
                 def rhs(x, t):
                     return self.predict(x[newaxis, :])[0]

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -361,12 +361,10 @@ class SINDy(BaseEstimator):
             raise TypeError("Input x must be a list")
 
         if self.discrete_time:
+            x = [validate_input(xi) for xi in x]
             if x_dot is None:
-                x_dot = []
-                for i in range(len(x)):
-                    x_tmp = validate_input(x[i])
-                    x[i] = x_tmp[:-1]
-                    x_dot.append(x_tmp[1:])
+                x_dot = [xi[1:] for xi in x]
+                x = [xi[:-1] for xi in x]
             else:
                 if not isinstance(x_dot, Sequence):
                     raise TypeError(
@@ -377,15 +375,13 @@ class SINDy(BaseEstimator):
         else:
             if x_dot is None:
                 if isinstance(t, Sequence):
-                    x_dot = []
-                    for i in range(len(x)):
-                        x[i] = validate_input(x[i], t[i])
-                        x_dot.append(self.differentiation_method(x[i], t[i]))
+                    x = [validate_input(xi, ti) for xi, ti in zip(x, t)]
+                    x_dot = [
+                        self.differentiation_method(xi, ti) for xi, ti in zip(x, t)
+                    ]
                 else:
-                    x_dot = []
-                    for i in range(len(x)):
-                        x[i] = validate_input(x[i], t)
-                        x_dot.append(self.differentiation_method(x[i], t))
+                    x = [validate_input(xi, t) for xi in x]
+                    x_dot = [self.differentiation_method(xi, t) for xi in x]
             else:
                 if not isinstance(x_dot, Sequence):
                     raise TypeError(
@@ -393,8 +389,10 @@ class SINDy(BaseEstimator):
                         "(i.e. for multiple trajectories)"
                     )
                 if isinstance(t, Sequence):
-                    x_dot = [validate_input(xd, t) for xd, t in zip(x_dot, t)]
+                    x = [validate_input(xi, ti) for xi, ti in zip(x, t)]
+                    x_dot = [validate_input(xd, ti) for xd, ti in zip(x_dot, t)]
                 else:
+                    x = [validate_input(xi, t) for xi in x]
                     x_dot = [validate_input(xd, t) for xd in x_dot]
 
         if return_array:

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -59,8 +59,8 @@ def validate_control_variables(
             )
 
         u_arr = []
-        for xi, control_variable in zip(x, u):
-            u_arr.append(_check_control_shape(xi, u, trim_last_point))
+        for xi, ui in zip(x, u):
+            u_arr.append(_check_control_shape(xi, ui, trim_last_point))
 
         if return_array:
             u_arr = np.vstack(u_arr)

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -43,7 +43,7 @@ def validate_control_variables(x, control_variables, multiple_trajectories):
     """
     Ensure that control_variables are compatible with the data x.
     If multiple_trajectories is True, convert control_variables from a list
-    into an array.
+    into an array (of concatenated list entries).
     """
     if multiple_trajectories:
         if not isinstance(x, Sequence):

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -82,8 +82,13 @@ def _check_control_shape(x, u, trim_last_point):
         raise e(
             "control variables u could not be converted to np.ndarray(dtype=float64)"
         )
+    if np.ndim(u) == 0:
+        u = u[np.newaxis]
     if x.shape[0] != u.shape[0]:
-        raise ValueError("control variables u must have same number of rows as x")
+        raise ValueError(
+            "control variables u must have same number of rows as x. "
+            "u has {} rows and x has {} rows".format(u.shape[0], x.shape[0])
+        )
 
     if np.ndim(u) == 1:
         u = u.reshape(-1, 1)

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -85,6 +85,8 @@ def _check_control_shape(x, u, trim_last_point):
     if x.shape[0] != u.shape[0]:
         raise ValueError("control variables u must have same number of rows as x")
 
+    if np.ndim(u) == 1:
+        u = u.reshape(-1, 1)
     return u[:-1] if trim_last_point else u
 
 

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -44,7 +44,7 @@ def validate_control_variables(
 ):
     """
     Ensure that control variables u are compatible with the data x.
-    If multiple_trajectories is True, convert u from a list
+    If `return_array` and `multiple_trajectories` are True, convert u from a list
     into an array (of concatenated list entries).
     """
     if multiple_trajectories:
@@ -58,9 +58,7 @@ def validate_control_variables(
                 "multiple_trajectories is True"
             )
 
-        u_arr = []
-        for xi, ui in zip(x, u):
-            u_arr.append(_check_control_shape(xi, ui, trim_last_point))
+        u_arr = [_check_control_shape(xi, ui, trim_last_point) for xi, ui in zip(x, u)]
 
         if return_array:
             u_arr = np.vstack(u_arr)

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -84,10 +84,10 @@ def _check_control_shape(x, u, trim_last_point):
         )
     if np.ndim(u) == 0:
         u = u[np.newaxis]
-    if x.shape[0] != u.shape[0]:
+    if len(x) != u.shape[0]:
         raise ValueError(
             "control variables u must have same number of rows as x. "
-            "u has {} rows and x has {} rows".format(u.shape[0], x.shape[0])
+            "u has {} rows and x has {} rows".format(u.shape[0], len(x))
         )
 
     if np.ndim(u) == 1:

--- a/test/property_tests/test_optimizers_complexity.py
+++ b/test/property_tests/test_optimizers_complexity.py
@@ -52,7 +52,7 @@ def test_complexity(n_samples, n_features, n_informative, random_state):
     for less_complex, more_complex in zip(optimizers, optimizers[1:]):
         # relax the condition to account for
         # noise and non-normalized threshold parameters
-        assert less_complex.complexity <= more_complex.complexity + 1
+        assert less_complex.complexity <= more_complex.complexity + 2
 
 
 @pytest.mark.parametrize(

--- a/test/test_sindyc.py
+++ b/test/test_sindyc.py
@@ -15,12 +15,12 @@ from pysindy.optimizers import STLSQ
 
 @pytest.fixture
 def data_lorenz_c_1d():
-    def u(t):
+    def u_fun(t):
         return np.sin(2 * t)
 
     def lorenz(z, t):
         return [
-            10 * (z[1] - z[0]) + u(t) ** 2,
+            10 * (z[1] - z[0]) + u_fun(t) ** 2,
             z[0] * (28 - z[2]) - z[1],
             z[0] * z[1] - 8 / 3 * z[2],
         ]
@@ -28,30 +28,30 @@ def data_lorenz_c_1d():
     t = np.linspace(0, 5, 500)
     x0 = [8, 27, -7]
     x = odeint(lorenz, x0, t)
-    u_eval = u(t)
+    u = u_fun(t)
 
-    return x, t, u_eval, u
+    return x, t, u, u_fun
 
 
 @pytest.fixture
 def data_lorenz_c_2d():
-    def u(t):
+    def u_fun(t):
         return np.column_stack([np.sin(2 * t), t ** 2])
 
     def lorenz(z, t):
-        u_eval = u(t)
+        u = u_fun(t)
         return [
-            10 * (z[1] - z[0]) + u_eval[0, 0] ** 2,
+            10 * (z[1] - z[0]) + u[0, 0] ** 2,
             z[0] * (28 - z[2]) - z[1],
-            z[0] * z[1] - 8 / 3 * z[2] - u_eval[0, 1],
+            z[0] * z[1] - 8 / 3 * z[2] - u[0, 1],
         ]
 
     t = np.linspace(0, 5, 500)
     x0 = [8, 27, -7]
     x = odeint(lorenz, x0, t)
-    u_eval = u(t)
+    u = u_fun(t)
 
-    return x, t, u_eval, u
+    return x, t, u, u_fun
 
 
 @pytest.fixture
@@ -89,57 +89,57 @@ def data_discrete_time_multiple_trajectories_c():
 
 
 def test_get_feature_names_len(data_lorenz_c_1d):
-    x, t, u_eval, _ = data_lorenz_c_1d
+    x, t, u, _ = data_lorenz_c_1d
     model = SINDy()
 
-    model.fit(x, u=u_eval, t=t)
+    model.fit(x, u=u, t=t)
 
     # Assumes default library is polynomial features of degree 2
     assert len(model.get_feature_names()) == 15
 
 
 def test_not_fitted(data_lorenz_c_1d):
-    x, t, u_eval, u = data_lorenz_c_1d
+    x, t, u, u_fun = data_lorenz_c_1d
     model = SINDy()
 
     with pytest.raises(NotFittedError):
-        model.predict(x, u=u_eval)
+        model.predict(x, u=u)
     with pytest.raises(NotFittedError):
-        model.simulate(x[0], t=t, u=u_eval)
+        model.simulate(x[0], t=t, u=u_fun)
 
 
 def test_improper_shape_input(data_1d):
     x, t = data_1d
-    u_eval = np.ones_like(x)
+    u = np.ones_like(x)
 
     # Ensure model successfully handles different data shapes
     model = SINDy()
-    model.fit(x.flatten(), u=u_eval, t=t)
+    model.fit(x.flatten(), u=u, t=t)
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x.flatten(), u=u_eval, t=t, x_dot=x.flatten())
+    model.fit(x.flatten(), u=u, t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x, u=u_eval, t=t, x_dot=x.flatten())
+    model.fit(x, u=u, t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x.flatten(), u=u_eval.reshape(-1, 1), t=t)
+    model.fit(x.flatten(), u=u.reshape(-1, 1), t=t)
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x.flatten(), u=u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
+    model.fit(x.flatten(), u=u.reshape(-1, 1), t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x, u=u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
+    model.fit(x, u=u.reshape(-1, 1), t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
     # Should fail if x and u have incompatible numbers of rows
     with pytest.raises(ValueError):
-        model.fit(x[:-1, :], u=u_eval, t=t[:-1])
+        model.fit(x[:-1, :], u=u, t=t[:-1])
 
 
 @pytest.mark.parametrize(
@@ -147,29 +147,29 @@ def test_improper_shape_input(data_1d):
     [pytest.lazy_fixture("data_lorenz_c_1d"), pytest.lazy_fixture("data_lorenz_c_2d")],
 )
 def test_mixed_inputs(data):
-    x, t, u_eval, _ = data
+    x, t, u, _ = data
 
     # Scalar t
     model = SINDy()
-    model.fit(x, u=u_eval, t=2)
+    model.fit(x, u=u, t=2)
     check_is_fitted(model)
 
     # x_dot is passed in
     model = SINDy()
-    model.fit(x, u=u_eval, x_dot=x)
+    model.fit(x, u=u, x_dot=x)
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x, u=u_eval, t=t, x_dot=x)
+    model.fit(x, u=u, t=t, x_dot=x)
     check_is_fitted(model)
 
 
 def test_bad_control_input(data_lorenz_c_1d):
-    x, t, u_eval, _ = data_lorenz_c_1d
+    x, t, u, _ = data_lorenz_c_1d
     model = SINDy()
 
     with pytest.raises(TypeError):
-        model.fit(x, u=set(u_eval), t=t)
+        model.fit(x, u=set(u), t=t)
 
 
 @pytest.mark.parametrize(
@@ -177,35 +177,35 @@ def test_bad_control_input(data_lorenz_c_1d):
     [pytest.lazy_fixture("data_lorenz_c_1d"), pytest.lazy_fixture("data_lorenz_c_2d")],
 )
 def test_bad_t(data):
-    x, t, u_eval, _ = data
+    x, t, u, _ = data
     model = SINDy()
 
     # No t
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval, t=None)
+        model.fit(x, u=u, t=None)
 
     # Invalid value of t
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval, t=-1)
+        model.fit(x, u=u, t=-1)
 
     # t is a list
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval, t=list(t))
+        model.fit(x, u=u, t=list(t))
 
     # Wrong number of time points
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval, t=t[:-1])
+        model.fit(x, u=u, t=t[:-1])
 
     # Two points in t out of order
     t[2], t[4] = t[4], t[2]
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval, t=t)
+        model.fit(x, u=u, t=t)
     t[2], t[4] = t[4], t[2]
 
     # Two matching times in t
     t[3] = t[5]
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval, t=t)
+        model.fit(x, u=u, t=t)
 
 
 @pytest.mark.parametrize(
@@ -222,10 +222,10 @@ def test_bad_t(data):
     ],
 )
 def test_predict(data, optimizer):
-    x, t, u_eval, _ = data
+    x, t, u, _ = data
     model = SINDy(optimizer=optimizer)
-    model.fit(x, u=u_eval, t=t)
-    x_dot = model.predict(x, u=u_eval)
+    model.fit(x, u=u, t=t)
+    x_dot = model.predict(x, u=u)
 
     assert x.shape == x_dot.shape
 
@@ -235,10 +235,10 @@ def test_predict(data, optimizer):
     [pytest.lazy_fixture("data_lorenz_c_1d"), pytest.lazy_fixture("data_lorenz_c_2d")],
 )
 def test_simulate(data):
-    x, t, u_eval, u = data
+    x, t, u, u_fun = data
     model = SINDy()
-    model.fit(x, u=u_eval, t=t)
-    x1 = model.simulate(x[0], t=t, u=u)
+    model.fit(x, u=u, t=t)
+    x1 = model.simulate(x[0], t=t, u=u_fun)
 
     assert len(x1) == len(t)
 
@@ -248,122 +248,122 @@ def test_simulate(data):
     [pytest.lazy_fixture("data_lorenz_c_1d"), pytest.lazy_fixture("data_lorenz_c_2d")],
 )
 def test_score(data):
-    x, t, u_eval, _ = data
+    x, t, u, _ = data
     model = SINDy()
-    model.fit(x, u=u_eval, t=t)
+    model.fit(x, u=u, t=t)
 
-    assert model.score(x, u=u_eval) <= 1
+    assert model.score(x, u=u) <= 1
 
-    assert model.score(x, u=u_eval, t=t) <= 1
+    assert model.score(x, u=u, t=t) <= 1
 
-    assert model.score(x, u=u_eval, x_dot=x) <= 1
+    assert model.score(x, u=u, x_dot=x) <= 1
 
-    assert model.score(x, u=u_eval, t=t, x_dot=x) <= 1
+    assert model.score(x, u=u, t=t, x_dot=x) <= 1
 
 
 def test_parallel(data_lorenz_c_1d):
-    x, t, u_eval, _ = data_lorenz_c_1d
+    x, t, u, _ = data_lorenz_c_1d
     model = SINDy(n_jobs=4)
-    model.fit(x, u=u_eval, t=t)
+    model.fit(x, u=u, t=t)
 
-    x_dot = model.predict(x, u=u_eval)
-    s = model.score(x, u=u_eval, x_dot=x_dot)
+    x_dot = model.predict(x, u=u)
+    s = model.score(x, u=u, x_dot=x_dot)
     assert s >= 0.95
 
 
 def test_fit_multiple_trajectores(data_multiple_trajctories):
     x, t = data_multiple_trajctories
-    u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
+    u = [np.ones((xi.shape[0], 2)) for xi in x]
 
     model = SINDy()
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval, t=t)
+        model.fit(x, u=u, t=t)
 
-    # Should fail if either x or u_eval is not a list
+    # Should fail if either x or u is not a list
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval[0], multiple_trajectories=True)
+        model.fit(x, u=u[0], multiple_trajectories=True)
 
     with pytest.raises(ValueError):
-        model.fit(x[0], u=u_eval, multiple_trajectories=True)
+        model.fit(x[0], u=u, multiple_trajectories=True)
 
-    # x and u_eval should be lists of the same length
+    # x and u should be lists of the same length
     with pytest.raises(ValueError):
-        model.fit([x[:-1]], u=u_eval, multiple_trajectories=True)
+        model.fit([x[:-1]], u=u, multiple_trajectories=True)
 
-    model.fit(x, u=u_eval, multiple_trajectories=True)
+    model.fit(x, u=u, multiple_trajectories=True)
     check_is_fitted(model)
 
-    model.fit(x, u=u_eval, t=t, multiple_trajectories=True)
-    assert model.score(x, u=u_eval, t=t, multiple_trajectories=True) > 0.8
+    model.fit(x, u=u, t=t, multiple_trajectories=True)
+    assert model.score(x, u=u, t=t, multiple_trajectories=True) > 0.8
 
     model = SINDy()
-    model.fit(x, u=u_eval, x_dot=x, multiple_trajectories=True)
+    model.fit(x, u=u, x_dot=x, multiple_trajectories=True)
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x, u=u_eval, t=t, x_dot=x, multiple_trajectories=True)
+    model.fit(x, u=u, t=t, x_dot=x, multiple_trajectories=True)
     check_is_fitted(model)
 
 
 def test_predict_multiple_trajectories(data_multiple_trajctories):
     x, t = data_multiple_trajctories
-    u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
+    u = [np.ones((xi.shape[0], 2)) for xi in x]
 
     model = SINDy()
-    model.fit(x, u=u_eval, t=t, multiple_trajectories=True)
+    model.fit(x, u=u, t=t, multiple_trajectories=True)
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.predict(x, u=u_eval)
+        model.predict(x, u=u)
 
-    p = model.predict(x, u=u_eval, multiple_trajectories=True)
+    p = model.predict(x, u=u, multiple_trajectories=True)
     assert len(p) == len(x)
 
 
 def test_score_multiple_trajectories(data_multiple_trajctories):
     x, t = data_multiple_trajctories
-    u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
+    u = [np.ones((xi.shape[0], 2)) for xi in x]
 
     model = SINDy()
-    model.fit(x, u=u_eval, t=t, multiple_trajectories=True)
+    model.fit(x, u=u, t=t, multiple_trajectories=True)
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.score(x, u=u_eval)
+        model.score(x, u=u)
 
-    s = model.score(x, u=u_eval, multiple_trajectories=True)
+    s = model.score(x, u=u, multiple_trajectories=True)
     assert s <= 1
 
-    s = model.score(x, u=u_eval, t=t, multiple_trajectories=True)
+    s = model.score(x, u=u, t=t, multiple_trajectories=True)
     assert s <= 1
 
-    s = model.score(x, u=u_eval, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u, x_dot=x, multiple_trajectories=True)
     assert s <= 1
 
-    s = model.score(x, u=u_eval, t=t, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u, t=t, x_dot=x, multiple_trajectories=True)
     assert s <= 1
 
 
 def test_fit_discrete_time(data_discrete_time_c):
-    x, u_eval = data_discrete_time_c
+    x, u = data_discrete_time_c
 
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u_eval)
+    model.fit(x, u=u)
     check_is_fitted(model)
 
     model = SINDy(discrete_time=True)
-    model.fit(x[:-1], u=u_eval[:-1], x_dot=x[1:])
+    model.fit(x[:-1], u=u[:-1], x_dot=x[1:])
     check_is_fitted(model)
 
 
 def test_simulate_discrete_time(data_discrete_time_c):
-    x, u_eval = data_discrete_time_c
+    x, u = data_discrete_time_c
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u_eval)
+    model.fit(x, u=u)
     n_steps = x.shape[0]
-    x1 = model.simulate(x[0], t=n_steps, u=u_eval)
+    x1 = model.simulate(x[0], t=n_steps, u=u)
 
     assert len(x1) == n_steps
 
@@ -371,83 +371,83 @@ def test_simulate_discrete_time(data_discrete_time_c):
 
 
 def test_predict_discrete_time(data_discrete_time_c):
-    x, u_eval = data_discrete_time_c
+    x, u = data_discrete_time_c
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u_eval)
-    assert len(model.predict(x, u=u_eval)) == len(x)
+    model.fit(x, u=u)
+    assert len(model.predict(x, u=u)) == len(x)
 
 
 def test_score_discrete_time(data_discrete_time_c):
-    x, u_eval = data_discrete_time_c
+    x, u = data_discrete_time_c
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u_eval)
-    assert model.score(x, u=u_eval) > 0.75
-    assert model.score(x, u=u_eval, x_dot=x) < 1
+    model.fit(x, u=u)
+    assert model.score(x, u=u) > 0.75
+    assert model.score(x, u=u, x_dot=x) < 1
 
 
 def test_fit_discrete_time_multiple_trajectories(
     data_discrete_time_multiple_trajectories_c,
 ):
-    x, u_eval = data_discrete_time_multiple_trajectories_c
+    x, u = data_discrete_time_multiple_trajectories_c
 
     # Should fail if multiple_trajectories flag is not set
     model = SINDy(discrete_time=True)
     with pytest.raises(ValueError):
-        model.fit(x, u=u_eval)
+        model.fit(x, u=u)
 
-    model.fit(x, u=u_eval, multiple_trajectories=True)
+    model.fit(x, u=u, multiple_trajectories=True)
     check_is_fitted(model)
 
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u_eval, x_dot=x, multiple_trajectories=True)
+    model.fit(x, u=u, x_dot=x, multiple_trajectories=True)
     check_is_fitted(model)
 
 
 def test_predict_discrete_time_multiple_trajectories(
     data_discrete_time_multiple_trajectories_c,
 ):
-    x, u_eval = data_discrete_time_multiple_trajectories_c
+    x, u = data_discrete_time_multiple_trajectories_c
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u_eval, multiple_trajectories=True)
+    model.fit(x, u=u, multiple_trajectories=True)
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.predict(x, u=u_eval)
+        model.predict(x, u=u)
 
-    y = model.predict(x, u=u_eval, multiple_trajectories=True)
+    y = model.predict(x, u=u, multiple_trajectories=True)
     assert len(y) == len(x)
 
 
 def test_score_discrete_time_multiple_trajectories(
     data_discrete_time_multiple_trajectories_c,
 ):
-    x, u_eval = data_discrete_time_multiple_trajectories_c
+    x, u = data_discrete_time_multiple_trajectories_c
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u_eval, multiple_trajectories=True)
+    model.fit(x, u=u, multiple_trajectories=True)
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.score(x, u=u_eval)
+        model.score(x, u=u)
 
-    s = model.score(x, u=u_eval, multiple_trajectories=True)
+    s = model.score(x, u=u, multiple_trajectories=True)
     assert s > 0.75
 
     # x is not its own derivative, so we expect bad performance here
-    s = model.score(x, u=u_eval, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u, x_dot=x, multiple_trajectories=True)
     assert s < 1
 
 
 def test_simulate_errors(data_lorenz_c_1d):
-    x, t, u_eval, u = data_lorenz_c_1d
+    x, t, u, u_fun = data_lorenz_c_1d
     model = SINDy()
-    model.fit(x, u=u_eval, t=t)
+    model.fit(x, u=u, t=t)
 
     with pytest.raises(ValueError):
-        model.simulate(x[0], t=1, u=u_eval)
+        model.simulate(x[0], t=1, u=u)
 
     model = SINDy(discrete_time=True)
     with pytest.raises(ValueError):
-        model.simulate(x[0], t=[1, 2], u=u_eval)
+        model.simulate(x[0], t=[1, 2], u=u)
 
 
 @pytest.mark.parametrize(
@@ -455,23 +455,23 @@ def test_simulate_errors(data_lorenz_c_1d):
     [({"threshold": 100}, UserWarning), ({"max_iter": 1}, ConvergenceWarning)],
 )
 def test_fit_warn(data_lorenz_c_1d, params, warning):
-    x, t, u_eval, _ = data_lorenz_c_1d
+    x, t, u, _ = data_lorenz_c_1d
     model = SINDy(optimizer=STLSQ(**params))
 
     with pytest.warns(warning):
-        model.fit(x, u=u_eval, t=t)
+        model.fit(x, u=u, t=t)
 
     with pytest.warns(None) as warn_record:
-        model.fit(x, u=u_eval, t=t, quiet=True)
+        model.fit(x, u=u, t=t, quiet=True)
 
     assert len(warn_record) == 0
 
 
 def test_u_omitted(data_lorenz_c_1d):
-    x, t, u_eval, _ = data_lorenz_c_1d
+    x, t, u, _ = data_lorenz_c_1d
     model = SINDy()
 
-    model.fit(x, u=u_eval, t=t)
+    model.fit(x, u=u, t=t)
 
     with pytest.raises(TypeError):
         model.predict(x)
@@ -484,30 +484,30 @@ def test_u_omitted(data_lorenz_c_1d):
 
 
 def test_extra_u_warn(data_lorenz_c_1d):
-    x, t, u_eval, _ = data_lorenz_c_1d
+    x, t, u, _ = data_lorenz_c_1d
     model = SINDy()
     model.fit(x, t=t)
 
     with pytest.warns(UserWarning):
-        model.predict(x, u=u_eval)
+        model.predict(x, u=u)
 
     with pytest.warns(UserWarning):
-        model.score(x, u=u_eval)
+        model.score(x, u=u)
 
     with pytest.warns(UserWarning):
-        model.simulate(x[0], t=t, u=u_eval)
+        model.simulate(x[0], t=t, u=u)
 
 
 def test_extra_u_warn_discrete(data_discrete_time_c):
-    x, u_eval = data_discrete_time_c
+    x, u = data_discrete_time_c
     model = SINDy(discrete_time=True)
     model.fit(x)
 
     with pytest.warns(UserWarning):
-        model.predict(x, u=u_eval)
+        model.predict(x, u=u)
 
     with pytest.warns(UserWarning):
-        model.score(x, u=u_eval)
+        model.score(x, u=u)
 
     with pytest.warns(UserWarning):
-        model.simulate(x[0], u=u_eval, t=10)
+        model.simulate(x[0], u=u, t=10)

--- a/test/test_sindyc.py
+++ b/test/test_sindyc.py
@@ -141,6 +141,10 @@ def test_improper_shape_input(data_1d):
     model.fit(x, u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
+    # Should fail if x and u have incompatible numbers of rows
+    with pytest.raises(ValueError):
+        model.fit(x[:-1, :], u_eval, t=t[:-1])
+
 
 @pytest.mark.parametrize(
     "data",
@@ -162,6 +166,14 @@ def test_mixed_inputs(data):
     model = SINDyC()
     model.fit(x, u_eval, t, x_dot=x)
     check_is_fitted(model)
+
+
+def test_bad_control_input(data_lorenz_c_1d):
+    x, t, u_eval, _ = data_lorenz_c_1d
+    model = SINDyC()
+
+    with pytest.raises(TypeError):
+        model.fit(x, set(u_eval), t=t)
 
 
 @pytest.mark.parametrize(
@@ -272,6 +284,17 @@ def test_fit_multiple_trajectores(data_multiple_trajctories):
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
         model.fit(x, u_eval, t=t)
+
+    # Should fail if either x or u_eval is not a list
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval[0], multiple_trajectories=True)
+
+    with pytest.raises(ValueError):
+        model.fit(x[0], u_eval, multiple_trajectories=True)
+
+    # x and u_eval should be lists of the same length
+    with pytest.raises(ValueError):
+        model.fit([x[:-1]], u_eval, multiple_trajectories=True)
 
     model.fit(x, u_eval, multiple_trajectories=True)
     check_is_fitted(model)

--- a/test/test_sindyc.py
+++ b/test/test_sindyc.py
@@ -1,0 +1,448 @@
+"""Unit tests for SINDyC: SINDy with control.
+
+SINDyC inherits from SINDy, so we focus on testing methods with
+new functionality.
+"""
+import numpy as np
+import pytest
+from scipy.integrate import odeint
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.exceptions import NotFittedError
+from sklearn.linear_model import ElasticNet
+from sklearn.linear_model import Lasso
+from sklearn.utils.validation import check_is_fitted
+
+from pysindy import SINDyC
+from pysindy.optimizers import SR3
+from pysindy.optimizers import STLSQ
+
+
+@pytest.fixture
+def data_lorenz_c_1d():
+    def u(t):
+        return np.sin(2 * t)
+
+    def lorenz(z, t):
+        return [
+            10 * (z[1] - z[0]) + u(t) ** 2,
+            z[0] * (28 - z[2]) - z[1],
+            z[0] * z[1] - 8 / 3 * z[2],
+        ]
+
+    t = np.linspace(0, 5, 500)
+    x0 = [8, 27, -7]
+    x = odeint(lorenz, x0, t)
+    u_eval = u(t)
+
+    return x, t, u_eval, u
+
+
+@pytest.fixture
+def data_lorenz_c_2d():
+    def u(t):
+        return np.column_stack([np.sin(2 * t), t ** 2])
+
+    def lorenz(z, t):
+        u_eval = u(t)
+        return [
+            10 * (z[1] - z[0]) + u_eval[0, 0] ** 2,
+            z[0] * (28 - z[2]) - z[1],
+            z[0] * z[1] - 8 / 3 * z[2] - u_eval[0, 1],
+        ]
+
+    t = np.linspace(0, 5, 500)
+    x0 = [8, 27, -7]
+    x = odeint(lorenz, x0, t)
+    u_eval = u(t)
+
+    return x, t, u_eval, u
+
+
+@pytest.fixture
+def data_discrete_time_c():
+    def logistic_map(x, mu, ui):
+        return mu * x * (1 - x) + ui
+
+    n_steps = 100
+    mu = 3.6
+
+    u = 0.01 * np.random.randn(n_steps)
+    x = np.zeros((n_steps))
+    x[0] = 0.5
+    for i in range(1, n_steps):
+        x[i] = logistic_map(x[i - 1], mu, u[i - 1])
+
+    return x, u
+
+
+@pytest.fixture
+def data_discrete_time_multiple_trajectories_c():
+    def logistic_map(x, mu, ui):
+        return mu * x * (1 - x) + ui
+
+    n_steps = 100
+    mus = [1, 2.3, 3.6]
+    u = [0.001 * np.random.randn(n_steps) for mu in mus]
+    x = [np.zeros((n_steps)) for mu in mus]
+    for i, mu in enumerate(mus):
+        x[i][0] = 0.5
+        for k in range(1, n_steps):
+            x[i][k] = logistic_map(x[i][k - 1], mu, u[i][k - 1])
+
+    return x, u
+
+
+def test_get_feature_names_len(data_lorenz_c_1d):
+    x, t, u_eval, _ = data_lorenz_c_1d
+    model = SINDyC()
+
+    model.fit(x, u_eval, t=t)
+
+    # Assumes default library is polynomial features of degree 2
+    assert len(model.get_feature_names()) == 15
+
+
+def test_not_fitted(data_lorenz_c_1d):
+    x, t, u_eval, u = data_lorenz_c_1d
+    model = SINDyC()
+
+    with pytest.raises(NotFittedError):
+        model.predict(x, u_eval)
+    with pytest.raises(NotFittedError):
+        model.simulate(x[0], u, t)
+
+
+def test_improper_shape_input(data_1d):
+    x, t = data_1d
+    u_eval = np.ones_like(x)
+
+    # Ensure model successfully handles different data shapes
+    model = SINDyC()
+    model.fit(x.flatten(), u_eval, t=t)
+    check_is_fitted(model)
+
+    model = SINDyC()
+    model.fit(x.flatten(), u_eval, t=t, x_dot=x.flatten())
+    check_is_fitted(model)
+
+    model = SINDyC()
+    model.fit(x, u_eval, t=t, x_dot=x.flatten())
+    check_is_fitted(model)
+
+    model = SINDyC()
+    model.fit(x.flatten(), u_eval.reshape(-1, 1), t=t)
+    check_is_fitted(model)
+
+    model = SINDyC()
+    model.fit(x.flatten(), u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
+    check_is_fitted(model)
+
+    model = SINDyC()
+    model.fit(x, u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
+    check_is_fitted(model)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [pytest.lazy_fixture("data_lorenz_c_1d"), pytest.lazy_fixture("data_lorenz_c_2d")],
+)
+def test_mixed_inputs(data):
+    x, t, u_eval, _ = data
+
+    # Scalar t
+    model = SINDyC()
+    model.fit(x, u_eval, t=2)
+    check_is_fitted(model)
+
+    # x_dot is passed in
+    model = SINDyC()
+    model.fit(x, u_eval, x_dot=x)
+    check_is_fitted(model)
+
+    model = SINDyC()
+    model.fit(x, u_eval, t, x_dot=x)
+    check_is_fitted(model)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [pytest.lazy_fixture("data_lorenz_c_1d"), pytest.lazy_fixture("data_lorenz_c_2d")],
+)
+def test_bad_t(data):
+    x, t, u_eval, _ = data
+    model = SINDyC()
+
+    # No t
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval, t=None)
+
+    # Invalid value of t
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval, t=-1)
+
+    # t is a list
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval, list(t))
+
+    # Wrong number of time points
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval, t[:-1])
+
+    # Two points in t out of order
+    t[2], t[4] = t[4], t[2]
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval, t)
+    t[2], t[4] = t[4], t[2]
+
+    # Two matching times in t
+    t[3] = t[5]
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval, t)
+
+
+@pytest.mark.parametrize(
+    "data, optimizer",
+    [
+        (pytest.lazy_fixture("data_lorenz_c_1d"), STLSQ()),
+        (pytest.lazy_fixture("data_lorenz_c_2d"), STLSQ()),
+        (pytest.lazy_fixture("data_lorenz_c_1d"), SR3()),
+        (pytest.lazy_fixture("data_lorenz_c_2d"), SR3()),
+        (pytest.lazy_fixture("data_lorenz_c_1d"), Lasso(fit_intercept=False)),
+        (pytest.lazy_fixture("data_lorenz_c_2d"), Lasso(fit_intercept=False)),
+        (pytest.lazy_fixture("data_lorenz_c_1d"), ElasticNet(fit_intercept=False)),
+        (pytest.lazy_fixture("data_lorenz_c_2d"), ElasticNet(fit_intercept=False)),
+    ],
+)
+def test_predict(data, optimizer):
+    x, t, u_eval, _ = data
+    model = SINDyC(optimizer=optimizer)
+    model.fit(x, u_eval, t)
+    x_dot = model.predict(x, u_eval)
+
+    assert x.shape == x_dot.shape
+
+
+@pytest.mark.parametrize(
+    "data",
+    [pytest.lazy_fixture("data_lorenz_c_1d"), pytest.lazy_fixture("data_lorenz_c_2d")],
+)
+def test_simulate(data):
+    x, t, u_eval, u = data
+    model = SINDyC()
+    model.fit(x, u_eval, t)
+    x1 = model.simulate(x[0], u, t)
+
+    assert len(x1) == len(t)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [pytest.lazy_fixture("data_lorenz_c_1d"), pytest.lazy_fixture("data_lorenz_c_2d")],
+)
+def test_score(data):
+    x, t, u_eval, _ = data
+    model = SINDyC()
+    model.fit(x, u_eval, t)
+
+    assert model.score(x, u_eval) <= 1
+
+    assert model.score(x, u_eval, t=t) <= 1
+
+    assert model.score(x, u_eval, x_dot=x) <= 1
+
+    assert model.score(x, u_eval, t=t, x_dot=x) <= 1
+
+
+def test_parallel(data_lorenz_c_1d):
+    x, t, u_eval, _ = data_lorenz_c_1d
+    model = SINDyC(n_jobs=4)
+    model.fit(x, u_eval, t)
+
+    x_dot = model.predict(x, u_eval)
+    s = model.score(x, u_eval, x_dot=x_dot)
+    assert s >= 0.95
+
+
+def test_fit_multiple_trajectores(data_multiple_trajctories):
+    x, t = data_multiple_trajctories
+    u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
+
+    model = SINDyC()
+
+    # Should fail if multiple_trajectories flag is not set
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval, t=t)
+
+    model.fit(x, u_eval, multiple_trajectories=True)
+    check_is_fitted(model)
+
+    model.fit(x, u_eval, t=t, multiple_trajectories=True)
+    assert model.score(x, u_eval, t=t, multiple_trajectories=True) > 0.8
+
+    model = SINDyC()
+    model.fit(x, u_eval, x_dot=x, multiple_trajectories=True)
+    check_is_fitted(model)
+
+    model = SINDyC()
+    model.fit(x, u_eval, t=t, x_dot=x, multiple_trajectories=True)
+    check_is_fitted(model)
+
+
+def test_predict_multiple_trajectories(data_multiple_trajctories):
+    x, t = data_multiple_trajctories
+    u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
+
+    model = SINDyC()
+    model.fit(x, u_eval, t=t, multiple_trajectories=True)
+
+    # Should fail if multiple_trajectories flag is not set
+    with pytest.raises(ValueError):
+        model.predict(x, u_eval)
+
+    p = model.predict(x, u_eval, multiple_trajectories=True)
+    assert len(p) == len(x)
+
+
+def test_score_multiple_trajectories(data_multiple_trajctories):
+    x, t = data_multiple_trajctories
+    u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
+
+    model = SINDyC()
+    model.fit(x, u_eval, t=t, multiple_trajectories=True)
+
+    # Should fail if multiple_trajectories flag is not set
+    with pytest.raises(ValueError):
+        model.score(x, u_eval)
+
+    s = model.score(x, u_eval, multiple_trajectories=True)
+    assert s <= 1
+
+    s = model.score(x, u_eval, t=t, multiple_trajectories=True)
+    assert s <= 1
+
+    s = model.score(x, u_eval, x_dot=x, multiple_trajectories=True)
+    assert s <= 1
+
+    s = model.score(x, u_eval, t=t, x_dot=x, multiple_trajectories=True)
+    assert s <= 1
+
+
+def test_fit_discrete_time(data_discrete_time_c):
+    x, u_eval = data_discrete_time_c
+
+    model = SINDyC(discrete_time=True)
+    model.fit(x, u_eval)
+    check_is_fitted(model)
+
+    model = SINDyC(discrete_time=True)
+    model.fit(x[:-1], u_eval[:-1], x_dot=x[1:])
+    check_is_fitted(model)
+
+
+def test_simulate_discrete_time(data_discrete_time_c):
+    x, u_eval = data_discrete_time_c
+    model = SINDyC(discrete_time=True)
+    model.fit(x, u_eval)
+    n_steps = x.shape[0]
+    x1 = model.simulate(x[0], u_eval, n_steps)
+
+    assert len(x1) == n_steps
+
+    # TODO: implement test using the stop_condition option
+
+
+def test_predict_discrete_time(data_discrete_time_c):
+    x, u_eval = data_discrete_time_c
+    model = SINDyC(discrete_time=True)
+    model.fit(x, u_eval)
+    assert len(model.predict(x, u_eval)) == len(x)
+
+
+def test_score_discrete_time(data_discrete_time_c):
+    x, u_eval = data_discrete_time_c
+    model = SINDyC(discrete_time=True)
+    model.fit(x, u_eval)
+    assert model.score(x, u_eval) > 0.75
+    assert model.score(x, u_eval, x_dot=x) < 1
+
+
+def test_fit_discrete_time_multiple_trajectories(
+    data_discrete_time_multiple_trajectories_c,
+):
+    x, u_eval = data_discrete_time_multiple_trajectories_c
+
+    # Should fail if multiple_trajectories flag is not set
+    model = SINDyC(discrete_time=True)
+    with pytest.raises(ValueError):
+        model.fit(x, u_eval)
+
+    model.fit(x, u_eval, multiple_trajectories=True)
+    check_is_fitted(model)
+
+    model = SINDyC(discrete_time=True)
+    model.fit(x, u_eval, x_dot=x, multiple_trajectories=True)
+    check_is_fitted(model)
+
+
+def test_predict_discrete_time_multiple_trajectories(
+    data_discrete_time_multiple_trajectories_c,
+):
+    x, u_eval = data_discrete_time_multiple_trajectories_c
+    model = SINDyC(discrete_time=True)
+    model.fit(x, u_eval, multiple_trajectories=True)
+
+    # Should fail if multiple_trajectories flag is not set
+    with pytest.raises(ValueError):
+        model.predict(x, u_eval)
+
+    y = model.predict(x, u_eval, multiple_trajectories=True)
+    assert len(y) == len(x)
+
+
+def test_score_discrete_time_multiple_trajectories(
+    data_discrete_time_multiple_trajectories_c,
+):
+    x, u_eval = data_discrete_time_multiple_trajectories_c
+    model = SINDyC(discrete_time=True)
+    model.fit(x, u_eval, multiple_trajectories=True)
+
+    # Should fail if multiple_trajectories flag is not set
+    with pytest.raises(ValueError):
+        model.score(x, u_eval)
+
+    s = model.score(x, u_eval, multiple_trajectories=True)
+    assert s > 0.75
+
+    # x is not its own derivative, so we expect bad performance here
+    s = model.score(x, u_eval, x_dot=x, multiple_trajectories=True)
+    assert s < 1
+
+
+def test_simulate_errors(data_lorenz_c_1d):
+    x, t, u_eval, u = data_lorenz_c_1d
+    model = SINDyC()
+    model.fit(x, u_eval, t)
+
+    with pytest.raises(ValueError):
+        model.simulate(x[0], u, t=1)
+
+    model = SINDyC(discrete_time=True)
+    with pytest.raises(ValueError):
+        model.simulate(x[0], u, t=[1, 2])
+
+
+@pytest.mark.parametrize(
+    "params, warning",
+    [({"threshold": 100}, UserWarning), ({"max_iter": 1}, ConvergenceWarning)],
+)
+def test_fit_warn(data_lorenz_c_1d, params, warning):
+    x, t, u_eval, _ = data_lorenz_c_1d
+    model = SINDyC(optimizer=STLSQ(**params))
+
+    with pytest.warns(warning):
+        model.fit(x, u_eval, t)
+
+    with pytest.warns(None) as warn_record:
+        model.fit(x, u_eval, t, quiet=True)
+
+    assert len(warn_record) == 0

--- a/test/test_sindyc.py
+++ b/test/test_sindyc.py
@@ -1,8 +1,4 @@
-"""Unit tests for SINDyC: SINDy with control.
-
-SINDyC inherits from SINDy, so we focus on testing methods with
-new functionality.
-"""
+"""Unit tests for SINDy with control."""
 import numpy as np
 import pytest
 from scipy.integrate import odeint
@@ -12,7 +8,7 @@ from sklearn.linear_model import ElasticNet
 from sklearn.linear_model import Lasso
 from sklearn.utils.validation import check_is_fitted
 
-from pysindy import SINDyC
+from pysindy import SINDy
 from pysindy.optimizers import SR3
 from pysindy.optimizers import STLSQ
 
@@ -94,9 +90,9 @@ def data_discrete_time_multiple_trajectories_c():
 
 def test_get_feature_names_len(data_lorenz_c_1d):
     x, t, u_eval, _ = data_lorenz_c_1d
-    model = SINDyC()
+    model = SINDy()
 
-    model.fit(x, u_eval, t=t)
+    model.fit(x, u=u_eval, t=t)
 
     # Assumes default library is polynomial features of degree 2
     assert len(model.get_feature_names()) == 15
@@ -104,12 +100,12 @@ def test_get_feature_names_len(data_lorenz_c_1d):
 
 def test_not_fitted(data_lorenz_c_1d):
     x, t, u_eval, u = data_lorenz_c_1d
-    model = SINDyC()
+    model = SINDy()
 
     with pytest.raises(NotFittedError):
-        model.predict(x, u_eval)
+        model.predict(x, u=u_eval)
     with pytest.raises(NotFittedError):
-        model.simulate(x[0], u, t)
+        model.simulate(x[0], t=t, u=u_eval)
 
 
 def test_improper_shape_input(data_1d):
@@ -117,33 +113,33 @@ def test_improper_shape_input(data_1d):
     u_eval = np.ones_like(x)
 
     # Ensure model successfully handles different data shapes
-    model = SINDyC()
-    model.fit(x.flatten(), u_eval, t=t)
+    model = SINDy()
+    model.fit(x.flatten(), u=u_eval, t=t)
     check_is_fitted(model)
 
-    model = SINDyC()
-    model.fit(x.flatten(), u_eval, t=t, x_dot=x.flatten())
+    model = SINDy()
+    model.fit(x.flatten(), u=u_eval, t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
-    model = SINDyC()
-    model.fit(x, u_eval, t=t, x_dot=x.flatten())
+    model = SINDy()
+    model.fit(x, u=u_eval, t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
-    model = SINDyC()
-    model.fit(x.flatten(), u_eval.reshape(-1, 1), t=t)
+    model = SINDy()
+    model.fit(x.flatten(), u=u_eval.reshape(-1, 1), t=t)
     check_is_fitted(model)
 
-    model = SINDyC()
-    model.fit(x.flatten(), u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
+    model = SINDy()
+    model.fit(x.flatten(), u=u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
-    model = SINDyC()
-    model.fit(x, u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
+    model = SINDy()
+    model.fit(x, u=u_eval.reshape(-1, 1), t=t, x_dot=x.flatten())
     check_is_fitted(model)
 
     # Should fail if x and u have incompatible numbers of rows
     with pytest.raises(ValueError):
-        model.fit(x[:-1, :], u_eval, t=t[:-1])
+        model.fit(x[:-1, :], u=u_eval, t=t[:-1])
 
 
 @pytest.mark.parametrize(
@@ -154,26 +150,26 @@ def test_mixed_inputs(data):
     x, t, u_eval, _ = data
 
     # Scalar t
-    model = SINDyC()
-    model.fit(x, u_eval, t=2)
+    model = SINDy()
+    model.fit(x, u=u_eval, t=2)
     check_is_fitted(model)
 
     # x_dot is passed in
-    model = SINDyC()
-    model.fit(x, u_eval, x_dot=x)
+    model = SINDy()
+    model.fit(x, u=u_eval, x_dot=x)
     check_is_fitted(model)
 
-    model = SINDyC()
-    model.fit(x, u_eval, t, x_dot=x)
+    model = SINDy()
+    model.fit(x, u=u_eval, t=t, x_dot=x)
     check_is_fitted(model)
 
 
 def test_bad_control_input(data_lorenz_c_1d):
     x, t, u_eval, _ = data_lorenz_c_1d
-    model = SINDyC()
+    model = SINDy()
 
     with pytest.raises(TypeError):
-        model.fit(x, set(u_eval), t=t)
+        model.fit(x, u=set(u_eval), t=t)
 
 
 @pytest.mark.parametrize(
@@ -182,34 +178,34 @@ def test_bad_control_input(data_lorenz_c_1d):
 )
 def test_bad_t(data):
     x, t, u_eval, _ = data
-    model = SINDyC()
+    model = SINDy()
 
     # No t
     with pytest.raises(ValueError):
-        model.fit(x, u_eval, t=None)
+        model.fit(x, u=u_eval, t=None)
 
     # Invalid value of t
     with pytest.raises(ValueError):
-        model.fit(x, u_eval, t=-1)
+        model.fit(x, u=u_eval, t=-1)
 
     # t is a list
     with pytest.raises(ValueError):
-        model.fit(x, u_eval, list(t))
+        model.fit(x, u=u_eval, t=list(t))
 
     # Wrong number of time points
     with pytest.raises(ValueError):
-        model.fit(x, u_eval, t[:-1])
+        model.fit(x, u=u_eval, t=t[:-1])
 
     # Two points in t out of order
     t[2], t[4] = t[4], t[2]
     with pytest.raises(ValueError):
-        model.fit(x, u_eval, t)
+        model.fit(x, u=u_eval, t=t)
     t[2], t[4] = t[4], t[2]
 
     # Two matching times in t
     t[3] = t[5]
     with pytest.raises(ValueError):
-        model.fit(x, u_eval, t)
+        model.fit(x, u=u_eval, t=t)
 
 
 @pytest.mark.parametrize(
@@ -227,9 +223,9 @@ def test_bad_t(data):
 )
 def test_predict(data, optimizer):
     x, t, u_eval, _ = data
-    model = SINDyC(optimizer=optimizer)
-    model.fit(x, u_eval, t)
-    x_dot = model.predict(x, u_eval)
+    model = SINDy(optimizer=optimizer)
+    model.fit(x, u=u_eval, t=t)
+    x_dot = model.predict(x, u=u_eval)
 
     assert x.shape == x_dot.shape
 
@@ -240,9 +236,9 @@ def test_predict(data, optimizer):
 )
 def test_simulate(data):
     x, t, u_eval, u = data
-    model = SINDyC()
-    model.fit(x, u_eval, t)
-    x1 = model.simulate(x[0], u, t)
+    model = SINDy()
+    model.fit(x, u=u_eval, t=t)
+    x1 = model.simulate(x[0], t=t, u=u)
 
     assert len(x1) == len(t)
 
@@ -253,25 +249,25 @@ def test_simulate(data):
 )
 def test_score(data):
     x, t, u_eval, _ = data
-    model = SINDyC()
-    model.fit(x, u_eval, t)
+    model = SINDy()
+    model.fit(x, u=u_eval, t=t)
 
-    assert model.score(x, u_eval) <= 1
+    assert model.score(x, u=u_eval) <= 1
 
-    assert model.score(x, u_eval, t=t) <= 1
+    assert model.score(x, u=u_eval, t=t) <= 1
 
-    assert model.score(x, u_eval, x_dot=x) <= 1
+    assert model.score(x, u=u_eval, x_dot=x) <= 1
 
-    assert model.score(x, u_eval, t=t, x_dot=x) <= 1
+    assert model.score(x, u=u_eval, t=t, x_dot=x) <= 1
 
 
 def test_parallel(data_lorenz_c_1d):
     x, t, u_eval, _ = data_lorenz_c_1d
-    model = SINDyC(n_jobs=4)
-    model.fit(x, u_eval, t)
+    model = SINDy(n_jobs=4)
+    model.fit(x, u=u_eval, t=t)
 
-    x_dot = model.predict(x, u_eval)
-    s = model.score(x, u_eval, x_dot=x_dot)
+    x_dot = model.predict(x, u=u_eval)
+    s = model.score(x, u=u_eval, x_dot=x_dot)
     assert s >= 0.95
 
 
@@ -279,35 +275,35 @@ def test_fit_multiple_trajectores(data_multiple_trajctories):
     x, t = data_multiple_trajctories
     u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
 
-    model = SINDyC()
+    model = SINDy()
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.fit(x, u_eval, t=t)
+        model.fit(x, u=u_eval, t=t)
 
     # Should fail if either x or u_eval is not a list
     with pytest.raises(ValueError):
-        model.fit(x, u_eval[0], multiple_trajectories=True)
+        model.fit(x, u=u_eval[0], multiple_trajectories=True)
 
     with pytest.raises(ValueError):
-        model.fit(x[0], u_eval, multiple_trajectories=True)
+        model.fit(x[0], u=u_eval, multiple_trajectories=True)
 
     # x and u_eval should be lists of the same length
     with pytest.raises(ValueError):
-        model.fit([x[:-1]], u_eval, multiple_trajectories=True)
+        model.fit([x[:-1]], u=u_eval, multiple_trajectories=True)
 
-    model.fit(x, u_eval, multiple_trajectories=True)
+    model.fit(x, u=u_eval, multiple_trajectories=True)
     check_is_fitted(model)
 
-    model.fit(x, u_eval, t=t, multiple_trajectories=True)
-    assert model.score(x, u_eval, t=t, multiple_trajectories=True) > 0.8
+    model.fit(x, u=u_eval, t=t, multiple_trajectories=True)
+    assert model.score(x, u=u_eval, t=t, multiple_trajectories=True) > 0.8
 
-    model = SINDyC()
-    model.fit(x, u_eval, x_dot=x, multiple_trajectories=True)
+    model = SINDy()
+    model.fit(x, u=u_eval, x_dot=x, multiple_trajectories=True)
     check_is_fitted(model)
 
-    model = SINDyC()
-    model.fit(x, u_eval, t=t, x_dot=x, multiple_trajectories=True)
+    model = SINDy()
+    model.fit(x, u=u_eval, t=t, x_dot=x, multiple_trajectories=True)
     check_is_fitted(model)
 
 
@@ -315,14 +311,14 @@ def test_predict_multiple_trajectories(data_multiple_trajctories):
     x, t = data_multiple_trajctories
     u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
 
-    model = SINDyC()
-    model.fit(x, u_eval, t=t, multiple_trajectories=True)
+    model = SINDy()
+    model.fit(x, u=u_eval, t=t, multiple_trajectories=True)
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.predict(x, u_eval)
+        model.predict(x, u=u_eval)
 
-    p = model.predict(x, u_eval, multiple_trajectories=True)
+    p = model.predict(x, u=u_eval, multiple_trajectories=True)
     assert len(p) == len(x)
 
 
@@ -330,44 +326,44 @@ def test_score_multiple_trajectories(data_multiple_trajctories):
     x, t = data_multiple_trajctories
     u_eval = [np.ones((xi.shape[0], 2)) for xi in x]
 
-    model = SINDyC()
-    model.fit(x, u_eval, t=t, multiple_trajectories=True)
+    model = SINDy()
+    model.fit(x, u=u_eval, t=t, multiple_trajectories=True)
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.score(x, u_eval)
+        model.score(x, u=u_eval)
 
-    s = model.score(x, u_eval, multiple_trajectories=True)
+    s = model.score(x, u=u_eval, multiple_trajectories=True)
     assert s <= 1
 
-    s = model.score(x, u_eval, t=t, multiple_trajectories=True)
+    s = model.score(x, u=u_eval, t=t, multiple_trajectories=True)
     assert s <= 1
 
-    s = model.score(x, u_eval, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u_eval, x_dot=x, multiple_trajectories=True)
     assert s <= 1
 
-    s = model.score(x, u_eval, t=t, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u_eval, t=t, x_dot=x, multiple_trajectories=True)
     assert s <= 1
 
 
 def test_fit_discrete_time(data_discrete_time_c):
     x, u_eval = data_discrete_time_c
 
-    model = SINDyC(discrete_time=True)
-    model.fit(x, u_eval)
+    model = SINDy(discrete_time=True)
+    model.fit(x, u=u_eval)
     check_is_fitted(model)
 
-    model = SINDyC(discrete_time=True)
-    model.fit(x[:-1], u_eval[:-1], x_dot=x[1:])
+    model = SINDy(discrete_time=True)
+    model.fit(x[:-1], u=u_eval[:-1], x_dot=x[1:])
     check_is_fitted(model)
 
 
 def test_simulate_discrete_time(data_discrete_time_c):
     x, u_eval = data_discrete_time_c
-    model = SINDyC(discrete_time=True)
-    model.fit(x, u_eval)
+    model = SINDy(discrete_time=True)
+    model.fit(x, u=u_eval)
     n_steps = x.shape[0]
-    x1 = model.simulate(x[0], u_eval, n_steps)
+    x1 = model.simulate(x[0], t=n_steps, u=u_eval)
 
     assert len(x1) == n_steps
 
@@ -376,17 +372,17 @@ def test_simulate_discrete_time(data_discrete_time_c):
 
 def test_predict_discrete_time(data_discrete_time_c):
     x, u_eval = data_discrete_time_c
-    model = SINDyC(discrete_time=True)
-    model.fit(x, u_eval)
-    assert len(model.predict(x, u_eval)) == len(x)
+    model = SINDy(discrete_time=True)
+    model.fit(x, u=u_eval)
+    assert len(model.predict(x, u=u_eval)) == len(x)
 
 
 def test_score_discrete_time(data_discrete_time_c):
     x, u_eval = data_discrete_time_c
-    model = SINDyC(discrete_time=True)
-    model.fit(x, u_eval)
-    assert model.score(x, u_eval) > 0.75
-    assert model.score(x, u_eval, x_dot=x) < 1
+    model = SINDy(discrete_time=True)
+    model.fit(x, u=u_eval)
+    assert model.score(x, u=u_eval) > 0.75
+    assert model.score(x, u=u_eval, x_dot=x) < 1
 
 
 def test_fit_discrete_time_multiple_trajectories(
@@ -395,15 +391,15 @@ def test_fit_discrete_time_multiple_trajectories(
     x, u_eval = data_discrete_time_multiple_trajectories_c
 
     # Should fail if multiple_trajectories flag is not set
-    model = SINDyC(discrete_time=True)
+    model = SINDy(discrete_time=True)
     with pytest.raises(ValueError):
-        model.fit(x, u_eval)
+        model.fit(x, u=u_eval)
 
-    model.fit(x, u_eval, multiple_trajectories=True)
+    model.fit(x, u=u_eval, multiple_trajectories=True)
     check_is_fitted(model)
 
-    model = SINDyC(discrete_time=True)
-    model.fit(x, u_eval, x_dot=x, multiple_trajectories=True)
+    model = SINDy(discrete_time=True)
+    model.fit(x, u=u_eval, x_dot=x, multiple_trajectories=True)
     check_is_fitted(model)
 
 
@@ -411,14 +407,14 @@ def test_predict_discrete_time_multiple_trajectories(
     data_discrete_time_multiple_trajectories_c,
 ):
     x, u_eval = data_discrete_time_multiple_trajectories_c
-    model = SINDyC(discrete_time=True)
-    model.fit(x, u_eval, multiple_trajectories=True)
+    model = SINDy(discrete_time=True)
+    model.fit(x, u=u_eval, multiple_trajectories=True)
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.predict(x, u_eval)
+        model.predict(x, u=u_eval)
 
-    y = model.predict(x, u_eval, multiple_trajectories=True)
+    y = model.predict(x, u=u_eval, multiple_trajectories=True)
     assert len(y) == len(x)
 
 
@@ -426,32 +422,32 @@ def test_score_discrete_time_multiple_trajectories(
     data_discrete_time_multiple_trajectories_c,
 ):
     x, u_eval = data_discrete_time_multiple_trajectories_c
-    model = SINDyC(discrete_time=True)
-    model.fit(x, u_eval, multiple_trajectories=True)
+    model = SINDy(discrete_time=True)
+    model.fit(x, u=u_eval, multiple_trajectories=True)
 
     # Should fail if multiple_trajectories flag is not set
     with pytest.raises(ValueError):
-        model.score(x, u_eval)
+        model.score(x, u=u_eval)
 
-    s = model.score(x, u_eval, multiple_trajectories=True)
+    s = model.score(x, u=u_eval, multiple_trajectories=True)
     assert s > 0.75
 
     # x is not its own derivative, so we expect bad performance here
-    s = model.score(x, u_eval, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u_eval, x_dot=x, multiple_trajectories=True)
     assert s < 1
 
 
 def test_simulate_errors(data_lorenz_c_1d):
     x, t, u_eval, u = data_lorenz_c_1d
-    model = SINDyC()
-    model.fit(x, u_eval, t)
+    model = SINDy()
+    model.fit(x, u=u_eval, t=t)
 
     with pytest.raises(ValueError):
-        model.simulate(x[0], u, t=1)
+        model.simulate(x[0], t=1, u=u_eval)
 
-    model = SINDyC(discrete_time=True)
+    model = SINDy(discrete_time=True)
     with pytest.raises(ValueError):
-        model.simulate(x[0], u, t=[1, 2])
+        model.simulate(x[0], t=[1, 2], u=u_eval)
 
 
 @pytest.mark.parametrize(
@@ -460,12 +456,58 @@ def test_simulate_errors(data_lorenz_c_1d):
 )
 def test_fit_warn(data_lorenz_c_1d, params, warning):
     x, t, u_eval, _ = data_lorenz_c_1d
-    model = SINDyC(optimizer=STLSQ(**params))
+    model = SINDy(optimizer=STLSQ(**params))
 
     with pytest.warns(warning):
-        model.fit(x, u_eval, t)
+        model.fit(x, u=u_eval, t=t)
 
     with pytest.warns(None) as warn_record:
-        model.fit(x, u_eval, t, quiet=True)
+        model.fit(x, u=u_eval, t=t, quiet=True)
 
     assert len(warn_record) == 0
+
+
+def test_u_omitted(data_lorenz_c_1d):
+    x, t, u_eval, _ = data_lorenz_c_1d
+    model = SINDy()
+
+    model.fit(x, u=u_eval, t=t)
+
+    with pytest.raises(TypeError):
+        model.predict(x)
+
+    with pytest.raises(TypeError):
+        model.score(x)
+
+    with pytest.raises(TypeError):
+        model.simulate(x[0], t=t)
+
+
+def test_extra_u_warn(data_lorenz_c_1d):
+    x, t, u_eval, _ = data_lorenz_c_1d
+    model = SINDy()
+    model.fit(x, t=t)
+
+    with pytest.warns(UserWarning):
+        model.predict(x, u=u_eval)
+
+    with pytest.warns(UserWarning):
+        model.score(x, u=u_eval)
+
+    with pytest.warns(UserWarning):
+        model.simulate(x[0], t=t, u=u_eval)
+
+
+def test_extra_u_warn_discrete(data_discrete_time_c):
+    x, u_eval = data_discrete_time_c
+    model = SINDy(discrete_time=True)
+    model.fit(x)
+
+    with pytest.warns(UserWarning):
+        model.predict(x, u=u_eval)
+
+    with pytest.warns(UserWarning):
+        model.score(x, u=u_eval)
+
+    with pytest.warns(UserWarning):
+        model.simulate(x[0], u=u_eval, t=10)


### PR DESCRIPTION
This pull request implements a `SINDyC` object (SINDy with control) #66 along with a full set of unit tests. The class is very similar to a standard `SINDy` object, but with an additional parameter, `u`, representing the control inputs, which is needed when the `fit`, `predict`, `score`, or `simulate` functions are called.

Instead of solving

    X' = Theta(X) * Xi

SINDyC solves

    X' = Theta(X, U) * Xi

where `U` is a matrix containing the control inputs.

Internally we essentially just ignore the control inputs when computing `X'`, but use them when computing the library `Theta(X, U)`.

This pull request also allows you to fit a model to a subset of the variables as in #40. You simply group all the variables in which you're interested inside `X` and the variables for which you aren't seeking differential equations inside `U`.

Other changes:
* Fix bugs in `SINDy.process_multiple_trajectories` causing `x` to be shrunk each time it was called with `discrete_time=True` and `x_dot=None`.