### PR TITLE
Fix check fitted

### DIFF
--- a/pysindy/feature_library/custom_library.py
+++ b/pysindy/feature_library/custom_library.py
@@ -89,7 +89,7 @@ class CustomLibrary(BaseFeatureLibrary):
         output_feature_names : list of string, length n_output_features
 
         """
-        check_is_fitted(self, "n_output_features_")
+        check_is_fitted(self)
         if input_features is None:
             input_features = ["x%d" % i for i in range(self.n_input_features_)]
         feature_names = []
@@ -147,7 +147,7 @@ class CustomLibrary(BaseFeatureLibrary):
             generated from applying the custom functions to the inputs.
 
         """
-        check_is_fitted(self, "n_output_features_")
+        check_is_fitted(self)
 
         X = check_array(X)
 

--- a/pysindy/optimizers/base.py
+++ b/pysindy/optimizers/base.py
@@ -8,6 +8,7 @@ from scipy import sparse
 from sklearn.linear_model import LinearRegression
 from sklearn.multioutput import MultiOutputRegressor
 from sklearn.utils.extmath import safe_sparse_dot
+from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.validation import check_X_y
 
 
@@ -27,6 +28,7 @@ def _rescale_data(X, y, sample_weight):
 class ComplexityMixin:
     @property
     def complexity(self):
+        check_is_fitted(self)
         return np.count_nonzero(self.coef_) + np.count_nonzero(self.intercept_)
 
 
@@ -73,9 +75,6 @@ class BaseOptimizer(LinearRegression, ComplexityMixin):
 
         self.max_iter = max_iter
         self.iters = 0
-        self.coef_ = None
-        self.ind_ = None
-        self.history_ = []
 
     # Force subclasses to implement this
     @abc.abstractmethod
@@ -127,7 +126,7 @@ class BaseOptimizer(LinearRegression, ComplexityMixin):
         self.iters = 0
         self.ind_ = np.ones((y.shape[1], x.shape[1]), dtype=bool)
         self.coef_ = np.linalg.lstsq(x, y, rcond=None)[0].T  # initial guess
-        self.history_.append(self.coef_)
+        self.history_ = [self.coef_]
 
         self._reduce(x, y, **reduce_kws)
         self.ind_ = np.abs(self.coef_) > 1e-14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-scikit-learn[alldeps]>=0.21
+scikit-learn[alldeps]>=0.23
 numpy
 scipy

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from numpy.linalg import norm
 from sklearn.base import BaseEstimator
+from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import ElasticNet
 from sklearn.linear_model import Lasso
 from sklearn.utils.validation import check_is_fitted
@@ -79,6 +80,22 @@ def test_fit(data, optimizer):
         assert opt.coef_.shape == (x.shape[1], x_dot.shape[1])
     else:
         assert opt.coef_.shape == (1, x.shape[1])
+
+
+@pytest.mark.parametrize(
+    "optimizer", [STLSQ(), SR3()],
+)
+def test_not_fitted(optimizer):
+    with pytest.raises(NotFittedError):
+        optimizer.predict(np.ones((1, 3)))
+
+
+@pytest.mark.parametrize(
+    "optimizer", [STLSQ(), SR3()],
+)
+def test_complexity_not_fitted(optimizer):
+    with pytest.raises(NotFittedError):
+        optimizer.complexity
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Updates required version of Scikit-learn from 0.21 to 0.23. The `check_is_fit` function had an extra positional argument `attributes` that version 0.23 makes into a keyword argument. Our calls to `check_is_fit` don't use the positional argument. See #81.
* Moves instantiation of some `BaseOptimizer` internal attributes (`coef_`, `history_`, and `ind_`) to the `fit` function. Previously these were defined in the class `__init__` function, causing the optimizers to appear as if they were fit before they actually were.
* Adds more stringent unit tests for checking when optimizers have been fit
* Adds a fit check to the `ComplexityMixin` class