### PR TITLE
bugfix - added missing _ to n_input_features_

### DIFF
--- a/pysindy/feature_library/weak_pde_library.py
+++ b/pysindy/feature_library/weak_pde_library.py
@@ -344,7 +344,7 @@ class WeakPDELibrary(BaseFeatureLibrary):
         if float(__version__[:3]) >= 1.0:
             n_features = self.n_features_in_
         else:
-            n_features = self.n_input_features
+            n_features = self.n_input_features_
         if input_features is None:
             input_features = ["x%d" % i for i in range(n_features)]
         if self.function_names is None:


### PR DESCRIPTION
I found an incorrectly named variable in thew weak pde library. It made weak form example notebooks fail. I have fixed it and checked that the weakform notebook can now run.