### PR TITLE
ENH: Raise explicit error when FROLS has linearly dependent columns.

### DIFF
--- a/pysindy/optimizers/frols.py
+++ b/pysindy/optimizers/frols.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from sklearn.linear_model import ridge_regression
 
@@ -104,7 +106,14 @@ class FROLS(BaseOptimizer):
         self.verbose = verbose
 
     def _normed_cov(self, a, b):
-        return np.vdot(a, b) / np.vdot(a, a)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", category=RuntimeWarning)
+            try:
+                return np.vdot(a, b) / np.vdot(a, a)
+            except RuntimeWarning:
+                raise ValueError(
+                    "Trying to orthogonalize linearly dependent columns created NaNs"
+                )
 
     def _select_function(self, x, y, sigma, skip=[]):
         n_features = x.shape[1]

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -1020,3 +1020,11 @@ def test_optimizers_verbose_cvxpy(data_lorenz, optimizer):
     model = optimizer(verbose_cvxpy=True)
     model.fit(x, x_dot)
     check_is_fitted(model)
+
+
+def test_frols_error_linear_dependence():
+    opt = FROLS(normalize_columns=True)
+    x = np.array([[1.0, 1.0]])
+    y = np.array([[1.0, 1.0]])
+    with pytest.raises(ValueError):
+        opt.fit(x, y)


### PR DESCRIPTION
Test added: test_frols_error_linear_dependence().

Test fails on master, passes on this branch.  Fixes #191 