### PR TITLE
External examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,9 +167,14 @@ At a minimum, we need to be able to run the example notebooks in the normal mode
    |-example_data.py # has functions to create/load data
    |-mock_data.py # has functions with same name as in example_data.py which create/load smaller datasets
    |-example.ipynb # run python examples/publish_notebook/<name_of_example> to generate this.  Needs packages in requirements-dev.txt
-   |-other files, if required (helper module, data, etc)
+   |-utils.py (Any other names example.py needs to import.  Any additional local modules imported by example.py need to be submodules of utils.py, e.g. utils.plotting)
 
-You can optimize your notebook for testing by checking ``__name__``.  When our tests run ``example.py`` they set the ``__name__`` global to ``"testing"``.  For instance, your notebook should determine whether to import from ``mock_data`` or ``example_data`` using this method.
+You can optimize your notebook for testing by checking ``__name__``.  When our tests run ``example.py`` they set the ``__name__`` global to ``"testing"``.  For instance, your notebook should determine whether to import from ``mock_data`` or ``example_data`` using this method (another example: you could also use this method to set ``max_iter``).  It's a bit arbitrary, but try to make your examples run in under ten seconds using the mock data.  You can use our test to verify your example in testing mode: 
+
+.. code-block::
+
+   pytest -k test_external --external-notebook="path/to/<name_of_example>"
+
 
 Contributing code
 ^^^^^^^^^^^^^^^^^

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,8 @@
 """
 Shared pytest fixtures for unit tests.
 """
+from pathlib import Path
+
 import numpy as np
 import pytest
 from scipy.integrate import solve_ivp
@@ -17,6 +19,29 @@ from pysindy.utils.odes import logistic_map_control
 from pysindy.utils.odes import logistic_map_multicontrol
 from pysindy.utils.odes import lorenz
 from pysindy.utils.odes import lorenz_control
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--external-notebook",
+        action="append",
+        default=[],
+        help=(
+            "name of notebook to test.  Only valid if running"
+            " test_notebooks.test_external"
+        ),
+    )
+
+
+def pytest_generate_tests(metafunc):
+    if "external_notebook" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "external_notebook",
+            [
+                Path(f.lstrip('"').rstrip('"'))
+                for f in metafunc.config.getoption("external_notebook")
+            ],
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
Allows testing of 3rd party examples that follow our format using new `test_external`.  Can verify this test works by pointing it to one of our own notebooks:

```
pytest -k test_external --external-notebook=examples/2_introduction_to_sindy
```