### PR TITLE
DOC: Credit Markus in contributors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,6 +317,8 @@ Related packages
 
 Contributors
 ------------
+This repository is a fork from `original work <https://github.com/Ohjeah/sparsereg>`_ by `Markus Quade <https://github.com/Ohjeah>`_.
+
 Thanks to the members of the community who have contributed to PySINDy!
 
 +-------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
In preparation for detaching fork from ohjeah/sparsereg.

Brian's email:
> I heard back from Markus today and he's fine with us detaching pysindy from sparsereg. But I told him we'd add a note and link at the top of the contributors section of the README to credit the initial contribution. What do you think?