### PR TITLE
DOC: Fix rst backticks to make CI green

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   hooks:
     - id: black
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+  rev: 5.0.4
   hooks:
     - id: flake8
       args: ["--config=setup.cfg"]

--- a/pysindy/optimizers/miosr.py
+++ b/pysindy/optimizers/miosr.py
@@ -28,7 +28,7 @@ class MIOSR(BaseOptimizer):
 
     by using type-1 specially ordered sets (SOS1) to encode the support of
     the coefficients. Can optionally add additional constraints on the
-    coefficients or access the gurobi `model` directly for advanced usage.
+    coefficients or access the gurobi model directly for advanced usage.
     See the following reference for additional details:
 
         Bertsimas, D. and Gurnee, W., 2022. Learning Sparse Nonlinear Dynamics


### PR DESCRIPTION
Solves the CI error:

```
sphinx.errors.SphinxWarning: /home/runner/work/pysindy/pysindy/pysindy/optimizers/miosr.py:docstring of pysindy.optimizers.miosr.MIOSR:12:'any' reference target not found: model
```