### PR TITLE
Remove codecov package

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ black
 pytest-cov
 pytest-lazy-fixture
 flake8-builtins-unleashed
-codecov
 cvxpy
 setuptools_scm
 setuptools_scm_git_archive


### PR DESCRIPTION
Codecov burninated their python package.  The codecov action should still work (I'll figure it out if it doesn't).  But it can't be a dependency or it will break the build.

https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259