### PR TITLE
Troubleshooting Coverage Report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         cd ..
     - name: Test with pytest
       run: |
-        coverage run --debug=trace --source=pysindy -m pytest test  && coverage report
+        coverage run --source=pysindy -m pytest test  && coverage xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         cd ..
     - name: Test with pytest
       run: |
-        pytest test --cov=pysindy --cov-report=xml
+        pytest test --cov=pysindy --cov-report=xml -vv
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         cd ..
     - name: Test with pytest
       run: |
-        pytest test --cov=pysindy --cov-report=xml -vv
+        coverage run --debug=trace --source=pysindy pytest test  && coverage report
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   Linting:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         cd ..
     - name: Test with pytest
       run: |
-        coverage run --debug=trace --source=pysindy pytest test  && coverage report
+        coverage run --debug=trace --source=pysindy -m pytest test  && coverage report
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
Fixes #336 and limits duplicate CI runs (instead of every push and every pull, only run on pushes and pulls to master).