### PR TITLE
Hotfix to enable intersphinx mapping to sklearn

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,8 @@ default_role = "any"
 html_sourcelink_suffix = ""
 
 intersphinx_mapping = {
-    "derivative": ("https://derivative.readthedocs.io/en/latest/", None)
+    "derivative": ("https://derivative.readthedocs.io/en/latest/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
 }
 
 # -- Extensions to the  Napoleon GoogleDocstring class ---------------------


### PR DESCRIPTION
Sphinx reads the public methods of all classes, and if one inherits from sklearn, it reads that method's docstring.  If that method contains a relative link in the rst, sphinx needs to know where to link it.

This will fix the current CI failure, new as of scikit-learn 1.3.  I'm going to give this a suspense time of a day in case anyone wants to read it, but its a hotfix blocking any PR's CI so I want to move it fast.