### PR TITLE
Implicit multiple trajectories

### DIFF
--- a/examples/1_feature_overview/example.ipynb
+++ b/examples/1_feature_overview/example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "73fd3bf6",
+   "id": "5ad7f790",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "439fe3d9",
+   "id": "b1ec6f40",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -27,13 +27,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "5f517c29",
+   "id": "2338df7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:22.611211Z",
-     "iopub.status.busy": "2023-07-10T22:16:22.609870Z",
-     "iopub.status.idle": "2023-07-10T22:16:23.510725Z",
-     "shell.execute_reply": "2023-07-10T22:16:23.509899Z"
+     "iopub.execute_input": "2023-07-25T20:44:58.675139Z",
+     "iopub.status.busy": "2023-07-25T20:44:58.673653Z",
+     "iopub.status.idle": "2023-07-25T20:44:59.906931Z",
+     "shell.execute_reply": "2023-07-25T20:44:59.906126Z"
     },
     "lines_to_next_cell": 0
    },
@@ -75,22 +75,24 @@
     "    yield\n",
     "    warnings.filters = filters\n",
     "\n",
+    "\n",
     "if __name__ == \"testing\":\n",
     "    import sys\n",
     "    import os\n",
+    "\n",
     "    sys.stdout = open(os.devnull, \"w\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "4bbd43f3",
+   "id": "6a8670dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:23.513154Z",
-     "iopub.status.busy": "2023-07-10T22:16:23.512816Z",
-     "iopub.status.idle": "2023-07-10T22:16:23.516189Z",
-     "shell.execute_reply": "2023-07-10T22:16:23.515486Z"
+     "iopub.execute_input": "2023-07-25T20:44:59.909510Z",
+     "iopub.status.busy": "2023-07-25T20:44:59.909177Z",
+     "iopub.status.idle": "2023-07-25T20:44:59.912584Z",
+     "shell.execute_reply": "2023-07-25T20:44:59.912010Z"
     }
    },
    "outputs": [],
@@ -101,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "774cbaed",
+   "id": "6563b296",
    "metadata": {},
    "source": [
     "### A note on solve_ivp vs odeint before we continue\n",
@@ -111,13 +113,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "96aa7f0d",
+   "id": "440b4cd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:23.518638Z",
-     "iopub.status.busy": "2023-07-10T22:16:23.518389Z",
-     "iopub.status.idle": "2023-07-10T22:16:23.521697Z",
-     "shell.execute_reply": "2023-07-10T22:16:23.521118Z"
+     "iopub.execute_input": "2023-07-25T20:44:59.914876Z",
+     "iopub.status.busy": "2023-07-25T20:44:59.914637Z",
+     "iopub.status.idle": "2023-07-25T20:44:59.917912Z",
+     "shell.execute_reply": "2023-07-25T20:44:59.917300Z"
     }
    },
    "outputs": [],
@@ -131,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d81deb1d",
+   "id": "edf7c8de",
    "metadata": {},
    "source": [
     "## Basic usage\n",
@@ -143,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0796936b",
+   "id": "ec0c9c65",
    "metadata": {},
    "source": [
     "### Train the model"
@@ -152,13 +154,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7d6cd62e",
+   "id": "36407798",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:23.524335Z",
-     "iopub.status.busy": "2023-07-10T22:16:23.524062Z",
-     "iopub.status.idle": "2023-07-10T22:16:23.703919Z",
-     "shell.execute_reply": "2023-07-10T22:16:23.703067Z"
+     "iopub.execute_input": "2023-07-25T20:44:59.920255Z",
+     "iopub.status.busy": "2023-07-25T20:44:59.920058Z",
+     "iopub.status.idle": "2023-07-25T20:45:00.061739Z",
+     "shell.execute_reply": "2023-07-25T20:45:00.061043Z"
     }
    },
    "outputs": [],
@@ -177,13 +179,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d647c368",
+   "id": "e48f09c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:23.706673Z",
-     "iopub.status.busy": "2023-07-10T22:16:23.706362Z",
-     "iopub.status.idle": "2023-07-10T22:16:23.731568Z",
-     "shell.execute_reply": "2023-07-10T22:16:23.730381Z"
+     "iopub.execute_input": "2023-07-25T20:45:00.064545Z",
+     "iopub.status.busy": "2023-07-25T20:45:00.064289Z",
+     "iopub.status.idle": "2023-07-25T20:45:00.089003Z",
+     "shell.execute_reply": "2023-07-25T20:45:00.087857Z"
     }
    },
    "outputs": [
@@ -206,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acc4aa28",
+   "id": "dc713bba",
    "metadata": {},
    "source": [
     "### Assess results on a test trajectory"
@@ -215,13 +217,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "d81dedc1",
+   "id": "d757d770",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:23.735912Z",
-     "iopub.status.busy": "2023-07-10T22:16:23.735425Z",
-     "iopub.status.idle": "2023-07-10T22:16:23.996323Z",
-     "shell.execute_reply": "2023-07-10T22:16:23.995668Z"
+     "iopub.execute_input": "2023-07-25T20:45:00.093497Z",
+     "iopub.status.busy": "2023-07-25T20:45:00.093017Z",
+     "iopub.status.idle": "2023-07-25T20:45:00.374604Z",
+     "shell.execute_reply": "2023-07-25T20:45:00.373967Z"
     }
    },
    "outputs": [
@@ -248,7 +250,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b00719f8",
+   "id": "b3a755b2",
    "metadata": {},
    "source": [
     "### Predict derivatives with learned model"
@@ -257,13 +259,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f258c463",
+   "id": "84d2d0d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:23.998704Z",
-     "iopub.status.busy": "2023-07-10T22:16:23.998306Z",
-     "iopub.status.idle": "2023-07-10T22:16:24.798958Z",
-     "shell.execute_reply": "2023-07-10T22:16:24.798261Z"
+     "iopub.execute_input": "2023-07-25T20:45:00.376766Z",
+     "iopub.status.busy": "2023-07-25T20:45:00.376523Z",
+     "iopub.status.idle": "2023-07-25T20:45:01.136750Z",
+     "shell.execute_reply": "2023-07-25T20:45:01.136032Z"
     }
    },
    "outputs": [
@@ -296,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9a60864",
+   "id": "98384faf",
    "metadata": {},
    "source": [
     "### Simulate forward in time"
@@ -305,13 +307,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "9ba377ae",
+   "id": "7bd2fddf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:24.801488Z",
-     "iopub.status.busy": "2023-07-10T22:16:24.801077Z",
-     "iopub.status.idle": "2023-07-10T22:16:30.361779Z",
-     "shell.execute_reply": "2023-07-10T22:16:30.360806Z"
+     "iopub.execute_input": "2023-07-25T20:45:01.139126Z",
+     "iopub.status.busy": "2023-07-25T20:45:01.138785Z",
+     "iopub.status.idle": "2023-07-25T20:45:07.126030Z",
+     "shell.execute_reply": "2023-07-25T20:45:07.125409Z"
     }
    },
    "outputs": [
@@ -361,7 +363,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a7241be",
+   "id": "04843d1f",
    "metadata": {},
    "source": [
     "## Different forms of input data\n",
@@ -371,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1c99378",
+   "id": "40d37847",
    "metadata": {},
    "source": [
     "### Single trajectory, pass in collection times"
@@ -380,13 +382,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "51c94b17",
+   "id": "1544c24b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:30.364645Z",
-     "iopub.status.busy": "2023-07-10T22:16:30.364310Z",
-     "iopub.status.idle": "2023-07-10T22:16:30.401790Z",
-     "shell.execute_reply": "2023-07-10T22:16:30.401117Z"
+     "iopub.execute_input": "2023-07-25T20:45:07.129067Z",
+     "iopub.status.busy": "2023-07-25T20:45:07.128608Z",
+     "iopub.status.idle": "2023-07-25T20:45:07.151269Z",
+     "shell.execute_reply": "2023-07-25T20:45:07.150191Z"
     }
    },
    "outputs": [
@@ -408,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c0a4988",
+   "id": "b1a86971",
    "metadata": {},
    "source": [
     "### Single trajectory, set default timestep\n",
@@ -418,13 +420,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "d4f37f20",
+   "id": "eb80c1c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:30.405613Z",
-     "iopub.status.busy": "2023-07-10T22:16:30.405165Z",
-     "iopub.status.idle": "2023-07-10T22:16:30.433935Z",
-     "shell.execute_reply": "2023-07-10T22:16:30.433308Z"
+     "iopub.execute_input": "2023-07-25T20:45:07.155359Z",
+     "iopub.status.busy": "2023-07-25T20:45:07.154860Z",
+     "iopub.status.idle": "2023-07-25T20:45:07.183611Z",
+     "shell.execute_reply": "2023-07-25T20:45:07.182545Z"
     }
    },
    "outputs": [
@@ -446,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "586dfadc",
+   "id": "b40ad578",
    "metadata": {},
    "source": [
     "### Single trajectory, pass in pre-computed derivatives"
@@ -455,13 +457,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "54fb8544",
+   "id": "4cf43383",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:30.437622Z",
-     "iopub.status.busy": "2023-07-10T22:16:30.437271Z",
-     "iopub.status.idle": "2023-07-10T22:16:30.499006Z",
-     "shell.execute_reply": "2023-07-10T22:16:30.498083Z"
+     "iopub.execute_input": "2023-07-25T20:45:07.188444Z",
+     "iopub.status.busy": "2023-07-25T20:45:07.187882Z",
+     "iopub.status.idle": "2023-07-25T20:45:07.243735Z",
+     "shell.execute_reply": "2023-07-25T20:45:07.242761Z"
     }
    },
    "outputs": [
@@ -487,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a041d0f4",
+   "id": "30bec97c",
    "metadata": {},
    "source": [
     "### Multiple trajectories\n",
@@ -497,13 +499,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "7b8100d4",
+   "id": "b8c85f72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:30.505088Z",
-     "iopub.status.busy": "2023-07-10T22:16:30.504393Z",
-     "iopub.status.idle": "2023-07-10T22:16:34.241408Z",
-     "shell.execute_reply": "2023-07-10T22:16:34.240353Z"
+     "iopub.execute_input": "2023-07-25T20:45:07.248148Z",
+     "iopub.status.busy": "2023-07-25T20:45:07.247569Z",
+     "iopub.status.idle": "2023-07-25T20:45:10.372203Z",
+     "shell.execute_reply": "2023-07-25T20:45:10.371216Z"
     }
    },
    "outputs": [
@@ -536,13 +538,13 @@
     "    )\n",
     "\n",
     "model = ps.SINDy()\n",
-    "model.fit(x_train_multi, t=dt, multiple_trajectories=True)\n",
+    "model.fit(x_train_multi, t=dt)\n",
     "model.print()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "23392e7a",
+   "id": "95bd6c20",
    "metadata": {},
    "source": [
     "### Multiple trajectories, different lengths of time\n",
@@ -552,13 +554,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "d28cdad8",
+   "id": "73858647",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:34.248580Z",
-     "iopub.status.busy": "2023-07-10T22:16:34.246613Z",
-     "iopub.status.idle": "2023-07-10T22:16:35.115252Z",
-     "shell.execute_reply": "2023-07-10T22:16:35.114207Z"
+     "iopub.execute_input": "2023-07-25T20:45:10.376584Z",
+     "iopub.status.busy": "2023-07-25T20:45:10.375786Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.136465Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.135324Z"
     }
    },
    "outputs": [
@@ -588,13 +590,13 @@
     "    t_train_multi.append(t)\n",
     "\n",
     "model = ps.SINDy()\n",
-    "model.fit(x_train_multi, t=t_train_multi, multiple_trajectories=True)\n",
+    "model.fit(x_train_multi, t=t_train_multi)\n",
     "model.print()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ce972125",
+   "id": "a6a42126",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -605,13 +607,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "cae87021",
+   "id": "edf5b390",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:35.119870Z",
-     "iopub.status.busy": "2023-07-10T22:16:35.119206Z",
-     "iopub.status.idle": "2023-07-10T22:16:35.138823Z",
-     "shell.execute_reply": "2023-07-10T22:16:35.137649Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.141287Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.140800Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.159071Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.158054Z"
     }
    },
    "outputs": [
@@ -645,7 +647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5929323d",
+   "id": "2792bee2",
    "metadata": {},
    "source": [
     "### Pandas DataFrame"
@@ -654,13 +656,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d16389a1",
+   "id": "a4e9eed8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:35.145266Z",
-     "iopub.status.busy": "2023-07-10T22:16:35.143642Z",
-     "iopub.status.idle": "2023-07-10T22:16:35.363014Z",
-     "shell.execute_reply": "2023-07-10T22:16:35.360940Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.164359Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.163544Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.418947Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.417476Z"
     }
    },
    "outputs": [
@@ -691,7 +693,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3022b955",
+   "id": "e4a90da6",
    "metadata": {},
    "source": [
     "## Optimization options\n",
@@ -700,7 +702,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e7c2419",
+   "id": "a531336b",
    "metadata": {},
    "source": [
     "### STLSQ - change parameters"
@@ -709,13 +711,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "4fd7896d",
+   "id": "174dc43f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:35.372097Z",
-     "iopub.status.busy": "2023-07-10T22:16:35.371642Z",
-     "iopub.status.idle": "2023-07-10T22:16:35.407926Z",
-     "shell.execute_reply": "2023-07-10T22:16:35.406898Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.423553Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.423122Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.457045Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.456024Z"
     }
    },
    "outputs": [
@@ -739,7 +741,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c688e7dd",
+   "id": "5dab8f5c",
    "metadata": {},
    "source": [
     "### STLSQ - verbose (print out optimization terms at each iteration)\n",
@@ -750,13 +752,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "de86919c",
+   "id": "d78471a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:35.413670Z",
-     "iopub.status.busy": "2023-07-10T22:16:35.412605Z",
-     "iopub.status.idle": "2023-07-10T22:16:35.450835Z",
-     "shell.execute_reply": "2023-07-10T22:16:35.449223Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.461270Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.460695Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.490152Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.489116Z"
     }
    },
    "outputs": [
@@ -784,7 +786,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac551054",
+   "id": "6704fb45",
    "metadata": {},
    "source": [
     "### SR3"
@@ -793,13 +795,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "3b22808e",
+   "id": "6035985b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:35.459690Z",
-     "iopub.status.busy": "2023-07-10T22:16:35.458990Z",
-     "iopub.status.idle": "2023-07-10T22:16:35.489737Z",
-     "shell.execute_reply": "2023-07-10T22:16:35.488242Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.494396Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.493819Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.516002Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.514984Z"
     }
    },
    "outputs": [
@@ -823,7 +825,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c96bf8f2",
+   "id": "108f5095",
    "metadata": {},
    "source": [
     "### SR3 - with trimming\n",
@@ -833,13 +835,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "b5a39675",
+   "id": "7398a8e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:35.500708Z",
-     "iopub.status.busy": "2023-07-10T22:16:35.499391Z",
-     "iopub.status.idle": "2023-07-10T22:16:35.813808Z",
-     "shell.execute_reply": "2023-07-10T22:16:35.811465Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.520194Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.519598Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.685532Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.684462Z"
     }
    },
    "outputs": [
@@ -887,7 +889,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5bd39437",
+   "id": "76589353",
    "metadata": {},
    "source": [
     "### SR3 regularizers\n",
@@ -897,13 +899,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "ff14fd01",
+   "id": "c5548a86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:35.820776Z",
-     "iopub.status.busy": "2023-07-10T22:16:35.819768Z",
-     "iopub.status.idle": "2023-07-10T22:16:35.989212Z",
-     "shell.execute_reply": "2023-07-10T22:16:35.988116Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.690180Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.689515Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.751620Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.750580Z"
     }
    },
    "outputs": [
@@ -914,11 +916,23 @@
       "L0 regularizer: \n",
       "(x0)' = -9.999 x0 + 9.999 x1\n",
       "(x1)' = 27.992 x0 + -0.999 x1 + -1.000 x0 x2\n",
-      "(x2)' = -2.666 x2 + 1.000 x0 x1\n",
+      "(x2)' = -2.666 x2 + 1.000 x0 x1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "L1 regularizer: \n",
       "(x0)' = -9.999 x0 + 9.999 x1\n",
       "(x1)' = 27.992 x0 + -0.999 x1 + -1.000 x0 x2\n",
-      "(x2)' = -2.666 x2 + 1.000 x0 x1\n",
+      "(x2)' = -2.666 x2 + 1.000 x0 x1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "L2 regularizer: \n",
       "(x0)' = -0.001 1 + -10.005 x0 + 10.003 x1\n",
       "(x1)' = -0.015 1 + 27.991 x0 + -0.998 x1 + 0.002 x2 + -1.000 x0 x2\n",
@@ -948,7 +962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5d58e43",
+   "id": "61aa34c9",
    "metadata": {},
    "source": [
     "### SR3 - with variable thresholding\n",
@@ -958,13 +972,13 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "f5fd35f6",
+   "id": "77f653ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:36.000019Z",
-     "iopub.status.busy": "2023-07-10T22:16:35.997909Z",
-     "iopub.status.idle": "2023-07-10T22:16:36.093835Z",
-     "shell.execute_reply": "2023-07-10T22:16:36.092470Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.755746Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.755049Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.795266Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.794208Z"
     }
    },
    "outputs": [
@@ -975,13 +989,7 @@
       "Threshold = 0.1 for all terms\n",
       "(x0)' = -9.999 x0 + 9.999 x1\n",
       "(x1)' = 27.992 x0 + -0.999 x1 + -1.000 x0 x2\n",
-      "(x2)' = -2.666 x2 + 1.000 x0 x1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "(x2)' = -2.666 x2 + 1.000 x0 x1\n",
       "Threshold = 0.1 for quadratic terms, else threshold = 1\n",
       "(x0)' = -9.999 x0 + 9.999 x1\n",
       "(x1)' = 25.563 x0 + -0.952 x0 x2\n",
@@ -1007,7 +1015,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c764abd4",
+   "id": "2a653cd5",
    "metadata": {},
    "source": [
     "It can be seen that the x1 term in the second equation correctly gets truncated with these thresholds.\n",
@@ -1019,13 +1027,13 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "45744433",
+   "id": "1772eb13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:36.101008Z",
-     "iopub.status.busy": "2023-07-10T22:16:36.099178Z",
-     "iopub.status.idle": "2023-07-10T22:16:36.111986Z",
-     "shell.execute_reply": "2023-07-10T22:16:36.110879Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.799989Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.799317Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.806596Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.805603Z"
     }
    },
    "outputs": [
@@ -1048,13 +1056,13 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "d4f988e7",
+   "id": "4a96714e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:36.120068Z",
-     "iopub.status.busy": "2023-07-10T22:16:36.118320Z",
-     "iopub.status.idle": "2023-07-10T22:16:36.146422Z",
-     "shell.execute_reply": "2023-07-10T22:16:36.145335Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.811056Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.810376Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.843776Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.842743Z"
     }
    },
    "outputs": [
@@ -1093,13 +1101,13 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "0e487dea",
+   "id": "82bbf504",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:36.153208Z",
-     "iopub.status.busy": "2023-07-10T22:16:36.151704Z",
-     "iopub.status.idle": "2023-07-10T22:16:36.196802Z",
-     "shell.execute_reply": "2023-07-10T22:16:36.195534Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.848609Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.847917Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.878680Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.877654Z"
     }
    },
    "outputs": [
@@ -1130,13 +1138,13 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "2b92fbee",
+   "id": "654a3212",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:36.204658Z",
-     "iopub.status.busy": "2023-07-10T22:16:36.202447Z",
-     "iopub.status.idle": "2023-07-10T22:16:36.217833Z",
-     "shell.execute_reply": "2023-07-10T22:16:36.216518Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.883165Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.882519Z",
+     "iopub.status.idle": "2023-07-25T20:45:11.887935Z",
+     "shell.execute_reply": "2023-07-25T20:45:11.886916Z"
     }
    },
    "outputs": [],
@@ -1154,13 +1162,13 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "69d1327b",
+   "id": "ae1de146",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:36.226261Z",
-     "iopub.status.busy": "2023-07-10T22:16:36.224103Z",
-     "iopub.status.idle": "2023-07-10T22:16:56.423455Z",
-     "shell.execute_reply": "2023-07-10T22:16:56.422760Z"
+     "iopub.execute_input": "2023-07-25T20:45:11.892500Z",
+     "iopub.status.busy": "2023-07-25T20:45:11.891761Z",
+     "iopub.status.idle": "2023-07-25T20:45:22.928006Z",
+     "shell.execute_reply": "2023-07-25T20:45:22.926250Z"
     }
    },
    "outputs": [
@@ -1211,7 +1219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab8789a5",
+   "id": "d065bccb",
    "metadata": {},
    "source": [
     "### MIOSR\n",
@@ -1225,13 +1233,13 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "90b5a4c4",
+   "id": "b371c257",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:56.430278Z",
-     "iopub.status.busy": "2023-07-10T22:16:56.429670Z",
-     "iopub.status.idle": "2023-07-10T22:16:56.442115Z",
-     "shell.execute_reply": "2023-07-10T22:16:56.439989Z"
+     "iopub.execute_input": "2023-07-25T20:45:22.932710Z",
+     "iopub.status.busy": "2023-07-25T20:45:22.932227Z",
+     "iopub.status.idle": "2023-07-25T20:45:22.939832Z",
+     "shell.execute_reply": "2023-07-25T20:45:22.938529Z"
     }
    },
    "outputs": [],
@@ -1247,7 +1255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "380f4e4a",
+   "id": "077aa59e",
    "metadata": {},
    "source": [
     "MIOSR can handle sparsity constraints in two ways: dimensionwise sparsity where the algorithm is fit once per each dimension, and global sparsity, where all dimensions are fit jointly to respect the overall sparsity constraint. Additionally, MIOSR can handle constraints and can be adapted to implement custom constraints by advanced users.\n",
@@ -1258,13 +1266,13 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "66384243",
+   "id": "72b56ccd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:56.446891Z",
-     "iopub.status.busy": "2023-07-10T22:16:56.446497Z",
-     "iopub.status.idle": "2023-07-10T22:16:56.559429Z",
-     "shell.execute_reply": "2023-07-10T22:16:56.558363Z"
+     "iopub.execute_input": "2023-07-25T20:45:22.944470Z",
+     "iopub.status.busy": "2023-07-25T20:45:22.943977Z",
+     "iopub.status.idle": "2023-07-25T20:45:23.023515Z",
+     "shell.execute_reply": "2023-07-25T20:45:23.022463Z"
     }
    },
    "outputs": [
@@ -1299,13 +1307,13 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "3bcdd95b",
+   "id": "3cb54468",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:56.566643Z",
-     "iopub.status.busy": "2023-07-10T22:16:56.565273Z",
-     "iopub.status.idle": "2023-07-10T22:16:56.788284Z",
-     "shell.execute_reply": "2023-07-10T22:16:56.787086Z"
+     "iopub.execute_input": "2023-07-25T20:45:23.027739Z",
+     "iopub.status.busy": "2023-07-25T20:45:23.027192Z",
+     "iopub.status.idle": "2023-07-25T20:45:23.143015Z",
+     "shell.execute_reply": "2023-07-25T20:45:23.141920Z"
     }
    },
    "outputs": [
@@ -1333,7 +1341,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d349b85",
+   "id": "11d83bca",
    "metadata": {},
    "source": [
     "### MIOSR (verbose) with equality constraints"
@@ -1342,13 +1350,13 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "b80bd8ef",
+   "id": "323a24fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:56.795979Z",
-     "iopub.status.busy": "2023-07-10T22:16:56.793203Z",
-     "iopub.status.idle": "2023-07-10T22:16:56.999445Z",
-     "shell.execute_reply": "2023-07-10T22:16:56.998234Z"
+     "iopub.execute_input": "2023-07-25T20:45:23.148957Z",
+     "iopub.status.busy": "2023-07-25T20:45:23.148386Z",
+     "iopub.status.idle": "2023-07-25T20:45:23.282655Z",
+     "shell.execute_reply": "2023-07-25T20:45:23.282148Z"
     }
    },
    "outputs": [
@@ -1657,7 +1665,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Explored 23 nodes (166 simplex iterations) in 0.10 seconds (0.00 work units)\n"
+      "Explored 23 nodes (166 simplex iterations) in 0.08 seconds (0.00 work units)\n"
      ]
     },
     {
@@ -1753,7 +1761,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ff22310",
+   "id": "3b28b495",
    "metadata": {},
    "source": [
     "See the [gurobi documentation](https://www.gurobi.com/documentation/9.5/refman/mip_logging.html) for more information on how to read the log output and this [tutorial](https://www.gurobi.com/resource/mip-basics/) on the basics of mixed-integer optimization."
@@ -1761,7 +1769,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccd42080",
+   "id": "a4d8cf42",
    "metadata": {},
    "source": [
     "### SSR (greedy algorithm)\n",
@@ -1771,13 +1779,13 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "c4dba59c",
+   "id": "1262a46e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:57.004933Z",
-     "iopub.status.busy": "2023-07-10T22:16:57.004425Z",
-     "iopub.status.idle": "2023-07-10T22:16:57.282098Z",
-     "shell.execute_reply": "2023-07-10T22:16:57.276010Z"
+     "iopub.execute_input": "2023-07-25T20:45:23.284723Z",
+     "iopub.status.busy": "2023-07-25T20:45:23.284430Z",
+     "iopub.status.idle": "2023-07-25T20:45:23.354482Z",
+     "shell.execute_reply": "2023-07-25T20:45:23.351898Z"
     }
    },
    "outputs": [
@@ -1801,7 +1809,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7473172a",
+   "id": "ff07f805",
    "metadata": {},
    "source": [
     "The alpha parameter is the same here as in the STLSQ optimizer. It determines the amount of L2 regularization to use, so if alpha is nonzero, this is doing Ridge regression rather than least-squares regression."
@@ -1810,13 +1818,13 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "8b4c7f42",
+   "id": "f47ccea7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:57.289360Z",
-     "iopub.status.busy": "2023-07-10T22:16:57.287576Z",
-     "iopub.status.idle": "2023-07-10T22:16:57.961689Z",
-     "shell.execute_reply": "2023-07-10T22:16:57.960191Z"
+     "iopub.execute_input": "2023-07-25T20:45:23.359020Z",
+     "iopub.status.busy": "2023-07-25T20:45:23.358126Z",
+     "iopub.status.idle": "2023-07-25T20:45:23.676877Z",
+     "shell.execute_reply": "2023-07-25T20:45:23.675851Z"
     }
    },
    "outputs": [
@@ -1839,7 +1847,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d926ac07",
+   "id": "5ebe5784",
    "metadata": {},
    "source": [
     "The kappa parameter determines how sparse a solution is desired."
@@ -1848,13 +1856,13 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "1498fd1a",
+   "id": "8b3ef434",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:57.976617Z",
-     "iopub.status.busy": "2023-07-10T22:16:57.973295Z",
-     "iopub.status.idle": "2023-07-10T22:16:58.477001Z",
-     "shell.execute_reply": "2023-07-10T22:16:58.476119Z"
+     "iopub.execute_input": "2023-07-25T20:45:23.681100Z",
+     "iopub.status.busy": "2023-07-25T20:45:23.680254Z",
+     "iopub.status.idle": "2023-07-25T20:45:23.954332Z",
+     "shell.execute_reply": "2023-07-25T20:45:23.953293Z"
     }
    },
    "outputs": [
@@ -1877,7 +1885,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d712dc8e",
+   "id": "575f0ae5",
    "metadata": {},
    "source": [
     "### FROLS (greedy algorithm)\n",
@@ -1887,13 +1895,13 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "9019e37f",
+   "id": "dfee4e05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:58.490423Z",
-     "iopub.status.busy": "2023-07-10T22:16:58.483344Z",
-     "iopub.status.idle": "2023-07-10T22:16:58.659625Z",
-     "shell.execute_reply": "2023-07-10T22:16:58.657314Z"
+     "iopub.execute_input": "2023-07-25T20:45:23.958839Z",
+     "iopub.status.busy": "2023-07-25T20:45:23.958263Z",
+     "iopub.status.idle": "2023-07-25T20:45:24.062080Z",
+     "shell.execute_reply": "2023-07-25T20:45:24.061429Z"
     }
    },
    "outputs": [
@@ -1916,7 +1924,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f0c8cea",
+   "id": "1a662acc",
    "metadata": {},
    "source": [
     "The kappa parameter determines how sparse a solution is desired."
@@ -1925,13 +1933,13 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "d2cba441",
+   "id": "3b9d007c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:58.665642Z",
-     "iopub.status.busy": "2023-07-10T22:16:58.664869Z",
-     "iopub.status.idle": "2023-07-10T22:16:58.801656Z",
-     "shell.execute_reply": "2023-07-10T22:16:58.799647Z"
+     "iopub.execute_input": "2023-07-25T20:45:24.065334Z",
+     "iopub.status.busy": "2023-07-25T20:45:24.065006Z",
+     "iopub.status.idle": "2023-07-25T20:45:24.164558Z",
+     "shell.execute_reply": "2023-07-25T20:45:24.163681Z"
     }
    },
    "outputs": [
@@ -1954,7 +1962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b825aed",
+   "id": "2cc3d9b2",
    "metadata": {},
    "source": [
     "### LASSO\n",
@@ -1964,13 +1972,13 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "8ce86588",
+   "id": "2e2fd3c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:58.806909Z",
-     "iopub.status.busy": "2023-07-10T22:16:58.806374Z",
-     "iopub.status.idle": "2023-07-10T22:16:59.441026Z",
-     "shell.execute_reply": "2023-07-10T22:16:59.439929Z"
+     "iopub.execute_input": "2023-07-25T20:45:24.167781Z",
+     "iopub.status.busy": "2023-07-25T20:45:24.167157Z",
+     "iopub.status.idle": "2023-07-25T20:45:24.391392Z",
+     "shell.execute_reply": "2023-07-25T20:45:24.390330Z"
     }
    },
    "outputs": [
@@ -1994,7 +2002,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1f4e16a",
+   "id": "a794a815",
    "metadata": {},
    "source": [
     "### Ensemble methods\n",
@@ -2004,13 +2012,13 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "a12783a0",
+   "id": "37c8672a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:16:59.450448Z",
-     "iopub.status.busy": "2023-07-10T22:16:59.449508Z",
-     "iopub.status.idle": "2023-07-10T22:17:02.319193Z",
-     "shell.execute_reply": "2023-07-10T22:17:02.318049Z"
+     "iopub.execute_input": "2023-07-25T20:45:24.395952Z",
+     "iopub.status.busy": "2023-07-25T20:45:24.394995Z",
+     "iopub.status.idle": "2023-07-25T20:45:25.303883Z",
+     "shell.execute_reply": "2023-07-25T20:45:25.303171Z"
     }
    },
    "outputs": [
@@ -2116,7 +2124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e66c5a",
+   "id": "cd8ad22f",
    "metadata": {},
    "source": [
     "## Differentiation options"
@@ -2124,7 +2132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0bbd99bd",
+   "id": "2ef3b42d",
    "metadata": {},
    "source": [
     "### Pass in pre-computed derivatives\n",
@@ -2134,13 +2142,13 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "d1eb6eef",
+   "id": "e5581ae0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:02.324288Z",
-     "iopub.status.busy": "2023-07-10T22:17:02.323414Z",
-     "iopub.status.idle": "2023-07-10T22:17:02.399135Z",
-     "shell.execute_reply": "2023-07-10T22:17:02.396198Z"
+     "iopub.execute_input": "2023-07-25T20:45:25.306877Z",
+     "iopub.status.busy": "2023-07-25T20:45:25.306399Z",
+     "iopub.status.idle": "2023-07-25T20:45:25.330552Z",
+     "shell.execute_reply": "2023-07-25T20:45:25.329452Z"
     }
    },
    "outputs": [
@@ -2164,7 +2172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7282b3a",
+   "id": "9e6a3bd1",
    "metadata": {},
    "source": [
     "### Drop end points from finite difference computation\n",
@@ -2174,13 +2182,13 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "85e5e50b",
+   "id": "a4ac3d9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:02.414665Z",
-     "iopub.status.busy": "2023-07-10T22:17:02.413568Z",
-     "iopub.status.idle": "2023-07-10T22:17:02.506468Z",
-     "shell.execute_reply": "2023-07-10T22:17:02.502118Z"
+     "iopub.execute_input": "2023-07-25T20:45:25.334790Z",
+     "iopub.status.busy": "2023-07-25T20:45:25.334311Z",
+     "iopub.status.idle": "2023-07-25T20:45:25.366243Z",
+     "shell.execute_reply": "2023-07-25T20:45:25.364818Z"
     }
    },
    "outputs": [
@@ -2204,7 +2212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8ab1227",
+   "id": "6559ff5b",
    "metadata": {},
    "source": [
     "### Differentiation along specific array axis\n",
@@ -2214,13 +2222,13 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "1bb8c457",
+   "id": "fe834423",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:02.521878Z",
-     "iopub.status.busy": "2023-07-10T22:17:02.521476Z",
-     "iopub.status.idle": "2023-07-10T22:17:03.781133Z",
-     "shell.execute_reply": "2023-07-10T22:17:03.779960Z"
+     "iopub.execute_input": "2023-07-25T20:45:25.370876Z",
+     "iopub.status.busy": "2023-07-25T20:45:25.370404Z",
+     "iopub.status.idle": "2023-07-25T20:45:25.862646Z",
+     "shell.execute_reply": "2023-07-25T20:45:25.861885Z"
     }
    },
    "outputs": [
@@ -2273,7 +2281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8bbab58",
+   "id": "f2495034",
    "metadata": {},
    "source": [
     "### Smoothed finite difference\n",
@@ -2283,13 +2291,13 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "5198a508",
+   "id": "5f124cee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:03.788558Z",
-     "iopub.status.busy": "2023-07-10T22:17:03.787514Z",
-     "iopub.status.idle": "2023-07-10T22:17:03.831002Z",
-     "shell.execute_reply": "2023-07-10T22:17:03.829773Z"
+     "iopub.execute_input": "2023-07-25T20:45:25.865206Z",
+     "iopub.status.busy": "2023-07-25T20:45:25.864650Z",
+     "iopub.status.idle": "2023-07-25T20:45:25.889911Z",
+     "shell.execute_reply": "2023-07-25T20:45:25.888743Z"
     }
    },
    "outputs": [
@@ -2313,7 +2321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e2e9de2",
+   "id": "af69cfcd",
    "metadata": {},
    "source": [
     "### More differentiation options\n",
@@ -2325,13 +2333,13 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "cb9dc338",
+   "id": "74be7ad6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:03.842575Z",
-     "iopub.status.busy": "2023-07-10T22:17:03.841837Z",
-     "iopub.status.idle": "2023-07-10T22:17:04.472261Z",
-     "shell.execute_reply": "2023-07-10T22:17:04.470783Z"
+     "iopub.execute_input": "2023-07-25T20:45:25.894401Z",
+     "iopub.status.busy": "2023-07-25T20:45:25.893915Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.129913Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.128539Z"
     }
    },
    "outputs": [
@@ -2355,7 +2363,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c819a9d3",
+   "id": "7c71e7c5",
    "metadata": {},
    "source": [
     "## Feature libraries"
@@ -2363,7 +2371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "339bcdfd",
+   "id": "ed1c7d47",
    "metadata": {},
    "source": [
     "### Custom feature names"
@@ -2372,13 +2380,13 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "37bac5fb",
+   "id": "3cb69fcb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:04.481487Z",
-     "iopub.status.busy": "2023-07-10T22:17:04.480419Z",
-     "iopub.status.idle": "2023-07-10T22:17:04.555542Z",
-     "shell.execute_reply": "2023-07-10T22:17:04.552341Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.134587Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.134157Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.159999Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.158921Z"
     }
    },
    "outputs": [
@@ -2401,7 +2409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef557633",
+   "id": "e480dc97",
    "metadata": {},
    "source": [
     "### Custom left-hand side when printing the model"
@@ -2410,13 +2418,13 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "c763350d",
+   "id": "8646174d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:04.566558Z",
-     "iopub.status.busy": "2023-07-10T22:17:04.562733Z",
-     "iopub.status.idle": "2023-07-10T22:17:04.632744Z",
-     "shell.execute_reply": "2023-07-10T22:17:04.631557Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.164935Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.164260Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.206189Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.205160Z"
     }
    },
    "outputs": [
@@ -2438,7 +2446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad61f1f8",
+   "id": "8a05597f",
    "metadata": {},
    "source": [
     "### Customize polynomial library\n",
@@ -2448,13 +2456,13 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "7edcbe2b",
+   "id": "9f03a2df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:04.641139Z",
-     "iopub.status.busy": "2023-07-10T22:17:04.639647Z",
-     "iopub.status.idle": "2023-07-10T22:17:04.686456Z",
-     "shell.execute_reply": "2023-07-10T22:17:04.683982Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.214806Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.214115Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.242586Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.241602Z"
     }
    },
    "outputs": [
@@ -2478,7 +2486,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a0005b1",
+   "id": "3c0f5d10",
    "metadata": {},
    "source": [
     "### Fourier library"
@@ -2487,13 +2495,13 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "3f4ae1b6",
+   "id": "6c9a563b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:04.696298Z",
-     "iopub.status.busy": "2023-07-10T22:17:04.693099Z",
-     "iopub.status.idle": "2023-07-10T22:17:04.762238Z",
-     "shell.execute_reply": "2023-07-10T22:17:04.760532Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.248053Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.247360Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.284066Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.283085Z"
     }
    },
    "outputs": [
@@ -2517,7 +2525,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84b54762",
+   "id": "ca405ef9",
    "metadata": {},
    "source": [
     "### Fully custom library\n",
@@ -2527,13 +2535,13 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "6e194b98",
+   "id": "1cdb5b06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:04.770259Z",
-     "iopub.status.busy": "2023-07-10T22:17:04.769558Z",
-     "iopub.status.idle": "2023-07-10T22:17:04.894807Z",
-     "shell.execute_reply": "2023-07-10T22:17:04.893259Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.288689Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.288028Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.349191Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.348151Z"
     }
    },
    "outputs": [
@@ -2541,14 +2549,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(x0)' = -9.999 x0 + 9.999 x1"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "(x0)' = -9.999 x0 + 9.999 x1\n",
       "(x1)' = 1.197 1/x0 + -50.011 1/x2 + -12.462 x0 + 9.291 x1 + 0.383 x2 + 0.882 sin(x0,x1) + 1.984 sin(x0,x2) + -0.464 sin(x1,x2)\n",
       "(x2)' = 0.874 1/x0 + -8.545 1/x2 + 0.114 x0 + 0.147 x1 + 3.659 sin(x0,x1) + -3.302 sin(x0,x2) + -3.094 sin(x1,x2)\n"
      ]
@@ -2579,7 +2580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "831ad420",
+   "id": "cb80b40f",
    "metadata": {},
    "source": [
     "### Fully custom library, default function names\n",
@@ -2589,13 +2590,13 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "bcde4b2f",
+   "id": "432bfa8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:04.906615Z",
-     "iopub.status.busy": "2023-07-10T22:17:04.903507Z",
-     "iopub.status.idle": "2023-07-10T22:17:05.043447Z",
-     "shell.execute_reply": "2023-07-10T22:17:05.042301Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.353692Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.353041Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.416916Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.415834Z"
     }
    },
    "outputs": [
@@ -2626,7 +2627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d763791",
+   "id": "2de665c4",
    "metadata": {},
    "source": [
     "### Identity library\n",
@@ -2636,13 +2637,13 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "115773c7",
+   "id": "93e4aa87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:05.055322Z",
-     "iopub.status.busy": "2023-07-10T22:17:05.049641Z",
-     "iopub.status.idle": "2023-07-10T22:17:05.151687Z",
-     "shell.execute_reply": "2023-07-10T22:17:05.150548Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.421432Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.420786Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.462200Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.461169Z"
     }
    },
    "outputs": [
@@ -2666,7 +2667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c2f90b2",
+   "id": "dfb273fd",
    "metadata": {},
    "source": [
     "### Concatenate two libraries\n",
@@ -2676,13 +2677,13 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "c8224049",
+   "id": "e7e5730e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:05.167482Z",
-     "iopub.status.busy": "2023-07-10T22:17:05.164502Z",
-     "iopub.status.idle": "2023-07-10T22:17:05.315227Z",
-     "shell.execute_reply": "2023-07-10T22:17:05.313835Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.466858Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.466196Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.495493Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.494673Z"
     }
    },
    "outputs": [
@@ -2727,7 +2728,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6464ffd",
+   "id": "e578ac35",
    "metadata": {},
    "source": [
     "### Tensor two libraries together\n",
@@ -2737,13 +2738,13 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "831b1c57",
+   "id": "c71d46a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:05.321968Z",
-     "iopub.status.busy": "2023-07-10T22:17:05.320909Z",
-     "iopub.status.idle": "2023-07-10T22:17:05.733237Z",
-     "shell.execute_reply": "2023-07-10T22:17:05.728710Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.499701Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.499226Z",
+     "iopub.status.idle": "2023-07-25T20:45:26.668624Z",
+     "shell.execute_reply": "2023-07-25T20:45:26.667640Z"
     }
    },
    "outputs": [
@@ -2770,13 +2771,13 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "5c6ce9ab",
+   "id": "c2aa636a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:05.739305Z",
-     "iopub.status.busy": "2023-07-10T22:17:05.738798Z",
-     "iopub.status.idle": "2023-07-10T22:17:07.632252Z",
-     "shell.execute_reply": "2023-07-10T22:17:07.631082Z"
+     "iopub.execute_input": "2023-07-25T20:45:26.673134Z",
+     "iopub.status.busy": "2023-07-25T20:45:26.672205Z",
+     "iopub.status.idle": "2023-07-25T20:45:27.414299Z",
+     "shell.execute_reply": "2023-07-25T20:45:27.413585Z"
     }
    },
    "outputs": [
@@ -2810,7 +2811,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82b971a6",
+   "id": "cd2a1439",
    "metadata": {},
    "source": [
     "### Generalized library\n",
@@ -2834,13 +2835,13 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "ddf03db6",
+   "id": "668fc963",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:07.639595Z",
-     "iopub.status.busy": "2023-07-10T22:17:07.638708Z",
-     "iopub.status.idle": "2023-07-10T22:17:07.756180Z",
-     "shell.execute_reply": "2023-07-10T22:17:07.754231Z"
+     "iopub.execute_input": "2023-07-25T20:45:27.417275Z",
+     "iopub.status.busy": "2023-07-25T20:45:27.416824Z",
+     "iopub.status.idle": "2023-07-25T20:45:27.460745Z",
+     "shell.execute_reply": "2023-07-25T20:45:27.459222Z"
     }
    },
    "outputs": [
@@ -2885,7 +2886,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9e4af07",
+   "id": "19825117",
    "metadata": {},
    "source": [
     "## SINDy with control (SINDYc)\n",
@@ -2897,7 +2898,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82555928",
+   "id": "1ccc88df",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2908,13 +2909,13 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "728495d3",
+   "id": "3bcd750c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:07.767568Z",
-     "iopub.status.busy": "2023-07-10T22:17:07.765716Z",
-     "iopub.status.idle": "2023-07-10T22:17:08.491457Z",
-     "shell.execute_reply": "2023-07-10T22:17:08.490669Z"
+     "iopub.execute_input": "2023-07-25T20:45:27.465281Z",
+     "iopub.status.busy": "2023-07-25T20:45:27.464800Z",
+     "iopub.status.idle": "2023-07-25T20:45:27.766724Z",
+     "shell.execute_reply": "2023-07-25T20:45:27.765908Z"
     }
    },
    "outputs": [],
@@ -2944,13 +2945,13 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "99c156f8",
+   "id": "c5215ed8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:08.497095Z",
-     "iopub.status.busy": "2023-07-10T22:17:08.495650Z",
-     "iopub.status.idle": "2023-07-10T22:17:08.549956Z",
-     "shell.execute_reply": "2023-07-10T22:17:08.549040Z"
+     "iopub.execute_input": "2023-07-25T20:45:27.769188Z",
+     "iopub.status.busy": "2023-07-25T20:45:27.768978Z",
+     "iopub.status.idle": "2023-07-25T20:45:27.798607Z",
+     "shell.execute_reply": "2023-07-25T20:45:27.797539Z"
     }
    },
    "outputs": [
@@ -2973,7 +2974,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61224adb",
+   "id": "0c4f2487",
    "metadata": {},
    "source": [
     "### Assess results on a test trajectory"
@@ -2982,13 +2983,13 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "faefdfd8",
+   "id": "88736b1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:08.564223Z",
-     "iopub.status.busy": "2023-07-10T22:17:08.554715Z",
-     "iopub.status.idle": "2023-07-10T22:17:09.630626Z",
-     "shell.execute_reply": "2023-07-10T22:17:09.628283Z"
+     "iopub.execute_input": "2023-07-25T20:45:27.802917Z",
+     "iopub.status.busy": "2023-07-25T20:45:27.802423Z",
+     "iopub.status.idle": "2023-07-25T20:45:28.453782Z",
+     "shell.execute_reply": "2023-07-25T20:45:28.452291Z"
     }
    },
    "outputs": [
@@ -3022,7 +3023,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b5c25cd",
+   "id": "27a20190",
    "metadata": {},
    "source": [
     "### Predict derivatives with learned model"
@@ -3031,13 +3032,13 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "93baf235",
+   "id": "504192ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:09.637832Z",
-     "iopub.status.busy": "2023-07-10T22:17:09.635997Z",
-     "iopub.status.idle": "2023-07-10T22:17:10.947908Z",
-     "shell.execute_reply": "2023-07-10T22:17:10.946564Z"
+     "iopub.execute_input": "2023-07-25T20:45:28.459124Z",
+     "iopub.status.busy": "2023-07-25T20:45:28.458434Z",
+     "iopub.status.idle": "2023-07-25T20:45:29.009448Z",
+     "shell.execute_reply": "2023-07-25T20:45:29.008775Z"
     }
    },
    "outputs": [
@@ -3070,7 +3071,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf404344",
+   "id": "c9a029e1",
    "metadata": {},
    "source": [
     "### Simulate forward in time (control input function known)\n",
@@ -3080,13 +3081,13 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "17eaf892",
+   "id": "e546284f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:10.953529Z",
-     "iopub.status.busy": "2023-07-10T22:17:10.952845Z",
-     "iopub.status.idle": "2023-07-10T22:17:26.283982Z",
-     "shell.execute_reply": "2023-07-10T22:17:26.283284Z"
+     "iopub.execute_input": "2023-07-25T20:45:29.011778Z",
+     "iopub.status.busy": "2023-07-25T20:45:29.011386Z",
+     "iopub.status.idle": "2023-07-25T20:45:41.368151Z",
+     "shell.execute_reply": "2023-07-25T20:45:41.367424Z"
     }
    },
    "outputs": [
@@ -3136,7 +3137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c302f378",
+   "id": "d1c477b1",
    "metadata": {},
    "source": [
     "### Simulate forward in time (unknown control input function)\n",
@@ -3146,13 +3147,13 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "a6dffe97",
+   "id": "d3756734",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:26.286808Z",
-     "iopub.status.busy": "2023-07-10T22:17:26.286543Z",
-     "iopub.status.idle": "2023-07-10T22:17:26.289956Z",
-     "shell.execute_reply": "2023-07-10T22:17:26.289377Z"
+     "iopub.execute_input": "2023-07-25T20:45:41.370702Z",
+     "iopub.status.busy": "2023-07-25T20:45:41.370454Z",
+     "iopub.status.idle": "2023-07-25T20:45:41.373978Z",
+     "shell.execute_reply": "2023-07-25T20:45:41.373311Z"
     }
    },
    "outputs": [],
@@ -3163,13 +3164,13 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "418644da",
+   "id": "12920bfd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:26.292788Z",
-     "iopub.status.busy": "2023-07-10T22:17:26.292195Z",
-     "iopub.status.idle": "2023-07-10T22:17:37.415443Z",
-     "shell.execute_reply": "2023-07-10T22:17:37.414831Z"
+     "iopub.execute_input": "2023-07-25T20:45:41.376475Z",
+     "iopub.status.busy": "2023-07-25T20:45:41.376186Z",
+     "iopub.status.idle": "2023-07-25T20:45:51.784956Z",
+     "shell.execute_reply": "2023-07-25T20:45:51.784262Z"
     }
    },
    "outputs": [
@@ -3210,7 +3211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "976306e8",
+   "id": "7190f1d9",
    "metadata": {},
    "source": [
     "## Implicit ODEs\n",
@@ -3233,13 +3234,13 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "id": "d1956aff",
+   "id": "2dcf1f66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:37.418352Z",
-     "iopub.status.busy": "2023-07-10T22:17:37.417790Z",
-     "iopub.status.idle": "2023-07-10T22:17:48.802073Z",
-     "shell.execute_reply": "2023-07-10T22:17:48.800314Z"
+     "iopub.execute_input": "2023-07-25T20:45:51.787385Z",
+     "iopub.status.busy": "2023-07-25T20:45:51.787164Z",
+     "iopub.status.idle": "2023-07-25T20:46:02.216108Z",
+     "shell.execute_reply": "2023-07-25T20:46:02.214708Z"
     }
    },
    "outputs": [
@@ -3406,7 +3407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b311fe8",
+   "id": "4bc4d167",
    "metadata": {},
    "source": [
     "## SINDy with control parameters (SINDyCP)\n",
@@ -3418,13 +3419,13 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "id": "db1da0fb",
+   "id": "2e31e153",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:48.806933Z",
-     "iopub.status.busy": "2023-07-10T22:17:48.806315Z",
-     "iopub.status.idle": "2023-07-10T22:17:51.395983Z",
-     "shell.execute_reply": "2023-07-10T22:17:51.395307Z"
+     "iopub.execute_input": "2023-07-25T20:46:02.220591Z",
+     "iopub.status.busy": "2023-07-25T20:46:02.220104Z",
+     "iopub.status.idle": "2023-07-25T20:46:04.702189Z",
+     "shell.execute_reply": "2023-07-25T20:46:04.701594Z"
     }
    },
    "outputs": [
@@ -3471,7 +3472,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c19c2653",
+   "id": "870a68f7",
    "metadata": {},
    "source": [
     "We construct a `parameter_library` and a `feature_library` to act on the input data `x` and the control input `u` independently. The `ParameterizedLibrary` is composed of products of the two libraries output features. This enables fine control over the library features, which is especially useful in the case of PDEs like those arising in pattern formation modeling. See this [notebook](https://github.com/dynamicslab/pysindy/blob/master/examples/17_parameterized_pattern_formation/17_parameterized_pattern_formation.ipynb) for examples."
@@ -3480,13 +3481,13 @@
   {
    "cell_type": "code",
    "execution_count": 63,
-   "id": "5f9ce4e5",
+   "id": "359cec92",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:51.398754Z",
-     "iopub.status.busy": "2023-07-10T22:17:51.398148Z",
-     "iopub.status.idle": "2023-07-10T22:17:51.420170Z",
-     "shell.execute_reply": "2023-07-10T22:17:51.418909Z"
+     "iopub.execute_input": "2023-07-25T20:46:04.705034Z",
+     "iopub.status.busy": "2023-07-25T20:46:04.704608Z",
+     "iopub.status.idle": "2023-07-25T20:46:04.721728Z",
+     "shell.execute_reply": "2023-07-25T20:46:04.720637Z"
     }
    },
    "outputs": [
@@ -3515,13 +3516,13 @@
     "model = ps.SINDy(\n",
     "    feature_library=lib, optimizer=opt, feature_names=[\"x\", \"r\"], discrete_time=True\n",
     ")\n",
-    "model.fit(xs_train, u=rs_train, multiple_trajectories=True)\n",
+    "model.fit(xs_train, u=rs_train)\n",
     "model.print()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "545c1b5c",
+   "id": "a9a4dc66",
    "metadata": {},
    "source": [
     "## PDEFIND Feature Overview\n",
@@ -3534,13 +3535,13 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "id": "d84ae809",
+   "id": "b6e77746",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:51.424896Z",
-     "iopub.status.busy": "2023-07-10T22:17:51.424367Z",
-     "iopub.status.idle": "2023-07-10T22:17:51.987307Z",
-     "shell.execute_reply": "2023-07-10T22:17:51.986612Z"
+     "iopub.execute_input": "2023-07-25T20:46:04.726064Z",
+     "iopub.status.busy": "2023-07-25T20:46:04.725595Z",
+     "iopub.status.idle": "2023-07-25T20:46:05.312871Z",
+     "shell.execute_reply": "2023-07-25T20:46:05.312192Z"
     }
    },
    "outputs": [
@@ -3615,7 +3616,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84951678",
+   "id": "e80d396d",
    "metadata": {},
    "source": [
     "### Weak formulation system identification improves robustness to noise.\n",
@@ -3625,13 +3626,13 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "58786876",
+   "id": "37937c74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:51.989440Z",
-     "iopub.status.busy": "2023-07-10T22:17:51.989216Z",
-     "iopub.status.idle": "2023-07-10T22:17:52.031639Z",
-     "shell.execute_reply": "2023-07-10T22:17:52.030859Z"
+     "iopub.execute_input": "2023-07-25T20:46:05.315839Z",
+     "iopub.status.busy": "2023-07-25T20:46:05.315262Z",
+     "iopub.status.idle": "2023-07-25T20:46:05.356979Z",
+     "shell.execute_reply": "2023-07-25T20:46:05.356169Z"
     }
    },
    "outputs": [],
@@ -3653,13 +3654,13 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "id": "8281b695",
+   "id": "db3c854f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:52.034080Z",
-     "iopub.status.busy": "2023-07-10T22:17:52.033877Z",
-     "iopub.status.idle": "2023-07-10T22:17:52.101252Z",
-     "shell.execute_reply": "2023-07-10T22:17:52.100596Z"
+     "iopub.execute_input": "2023-07-25T20:46:05.359921Z",
+     "iopub.status.busy": "2023-07-25T20:46:05.359460Z",
+     "iopub.status.idle": "2023-07-25T20:46:05.423798Z",
+     "shell.execute_reply": "2023-07-25T20:46:05.423142Z"
     }
    },
    "outputs": [
@@ -3682,7 +3683,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58b82c65",
+   "id": "d9587a19",
    "metadata": {},
    "source": [
     "### GeneralizedLibrary\n",
@@ -3704,13 +3705,13 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "id": "b9fad5d8",
+   "id": "5a9a5787",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:52.103650Z",
-     "iopub.status.busy": "2023-07-10T22:17:52.103316Z",
-     "iopub.status.idle": "2023-07-10T22:17:53.020175Z",
-     "shell.execute_reply": "2023-07-10T22:17:53.019466Z"
+     "iopub.execute_input": "2023-07-25T20:46:05.426588Z",
+     "iopub.status.busy": "2023-07-25T20:46:05.426332Z",
+     "iopub.status.idle": "2023-07-25T20:46:06.325663Z",
+     "shell.execute_reply": "2023-07-25T20:46:06.324981Z"
     }
    },
    "outputs": [
@@ -3845,13 +3846,13 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "917e920e",
+   "id": "942df264",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-07-10T22:17:53.023024Z",
-     "iopub.status.busy": "2023-07-10T22:17:53.022803Z",
-     "iopub.status.idle": "2023-07-10T22:17:53.735852Z",
-     "shell.execute_reply": "2023-07-10T22:17:53.735216Z"
+     "iopub.execute_input": "2023-07-25T20:46:06.327909Z",
+     "iopub.status.busy": "2023-07-25T20:46:06.327651Z",
+     "iopub.status.idle": "2023-07-25T20:46:07.117539Z",
+     "shell.execute_reply": "2023-07-25T20:46:07.116832Z"
     }
    },
    "outputs": [

--- a/examples/1_feature_overview/example.py
+++ b/examples/1_feature_overview/example.py
@@ -207,7 +207,7 @@ for i in range(n_trajectories):
     )
 
 model = ps.SINDy()
-model.fit(x_train_multi, t=dt, multiple_trajectories=True)
+model.fit(x_train_multi, t=dt)
 model.print()
 
 # %% [markdown]
@@ -230,7 +230,7 @@ for i in range(n_trajectories):
     t_train_multi.append(t)
 
 model = ps.SINDy()
-model.fit(x_train_multi, t=t_train_multi, multiple_trajectories=True)
+model.fit(x_train_multi, t=t_train_multi)
 model.print()
 
 # %% [markdown]
@@ -1209,7 +1209,7 @@ opt = ps.STLSQ(threshold=1e-1, normalize_columns=False)
 model = ps.SINDy(
     feature_library=lib, optimizer=opt, feature_names=["x", "r"], discrete_time=True
 )
-model.fit(xs_train, u=rs_train, multiple_trajectories=True)
+model.fit(xs_train, u=rs_train)
 model.print()
 
 # %% [markdown]

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -535,6 +535,10 @@ class SINDy(BaseEstimator):
             Time derivatives computed by using the model's differentiation
             method
         """
+        warnings.warn(
+            "SINDy.differentiate is deprecated.  "
+            "Call the differentiation_method parameter"
+        )
         if t is None:
             t = self.t_default
         if self.discrete_time:

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 from itertools import product
 from typing import Collection
@@ -778,14 +779,32 @@ def _check_multiple_trajectories(x, x_dot, u) -> bool:
 
     """
     SequenceOrNone = Union[Sequence, None]
-    mixed_trajectories = (
-        isinstance(x, Sequence)
-        and (not isinstance(x_dot, SequenceOrNone) or not isinstance(u, SequenceOrNone))
-        or isinstance(x_dot, Sequence)
-        and not isinstance(x, Sequence)
-        or isinstance(u, Sequence)
-        and not isinstance(x, Sequence)
-    )
+    if sys.version_info.minor < 10:
+        mixed_trajectories = (
+            isinstance(x, Sequence)
+            and (
+                not isinstance(x_dot, Sequence)
+                and x_dot is not None
+                or not isinstance(u, Sequence)
+                and u is not None
+            )
+            or isinstance(x_dot, Sequence)
+            and not isinstance(x, Sequence)
+            or isinstance(u, Sequence)
+            and not isinstance(x, Sequence)
+        )
+    else:
+        mixed_trajectories = (
+            isinstance(x, Sequence)
+            and (
+                not isinstance(x_dot, SequenceOrNone)
+                or not isinstance(u, SequenceOrNone)
+            )
+            or isinstance(x_dot, Sequence)
+            and not isinstance(x, Sequence)
+            or isinstance(u, Sequence)
+            and not isinstance(x, Sequence)
+        )
     if mixed_trajectories:
         raise TypeError(
             "If x, x_dot, or u are a Sequence of trajectories, each must be a Sequence"

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -6,6 +6,8 @@ from scipy.optimize import bisect
 from sklearn.base import MultiOutputMixin
 from sklearn.utils.validation import check_array
 
+from .axes import AxesArray
+
 # Define a special object for the default value of t in
 # validate_input. Normally we would set the default
 # value of t to be None, but it is possible for the user
@@ -89,29 +91,31 @@ def validate_no_reshape(x, t=T_DEFAULT):
     return x
 
 
-def validate_control_variables(x, u, trim_last_point=False):
+def validate_control_variables(
+    x: Sequence[AxesArray], u: Sequence[AxesArray], trim_last_point: bool = False
+) -> None:
     """Ensure that control variables u are compatible with the data x.
 
-    Trims last control variable timepoint if set to True
+    Args:
+        x: trajectories of system variables
+        u: trajectories of control variables
+        trim_last_point: whether to remove last time point of controls
     """
     if not isinstance(x, Sequence):
-        raise ValueError("x must be a list when multiple_trajectories is True")
+        raise ValueError("x must be a Sequence")
     if not isinstance(u, Sequence):
-        raise ValueError("u must be a list when multiple_trajectories is True")
+        raise ValueError("u must be a Sequence")
     if len(x) != len(u):
-        raise ValueError(
-            "x and u must be lists of the same length when "
-            "multiple_trajectories is True"
-        )
+        raise ValueError("x and u must be the same length")
 
     def _check_control_shape(x, u, trim_last_point):
         """
         Compare shape of control variable u against x.
         """
-        if u.shape[u.ax_time] != x.shape[x.ax_time]:
+        if u.n_time != x.n_time:
             raise ValueError(
-                "control variables u must have same number of rows as x. "
-                "u has {} rows and x has {} rows".format(u.shape[0], len(x))
+                "control variables u must have same number of time points as x. "
+                f"u has {u.n_time} time points and x has {x.n_time} time points"
             )
         return u[:-1] if trim_last_point else u
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -69,7 +69,7 @@ def data_lorenz():
 
 
 @pytest.fixture
-def data_multiple_trajctories():
+def data_multiple_trajectories():
 
     n_points = [100, 200, 500]
     initial_conditions = [

--- a/test/test_feature_library.py
+++ b/test/test_feature_library.py
@@ -648,7 +648,7 @@ def test_parameterized_library(diffuse_multiple_trajectories):
     model = SINDy(
         feature_library=pde_lib, optimizer=optimizer, feature_names=["u", "c"]
     )
-    model.fit(xs, u=us, multiple_trajectories=True, t=t)
+    model.fit(xs, u=us, t=t)
     assert abs(model.coefficients()[0][4] - 1) < 1e-2
     assert np.all(model.coefficients()[0][:4] == 0)
     assert np.all(model.coefficients()[0][5:] == 0)
@@ -657,7 +657,7 @@ def test_parameterized_library(diffuse_multiple_trajectories):
     model = SINDy(
         feature_library=weak_lib, optimizer=optimizer, feature_names=["u", "c"]
     )
-    model.fit(xs, u=us, multiple_trajectories=True, t=t)
+    model.fit(xs, u=us, t=t)
     assert abs(model.coefficients()[0][4] - 1) < 1e-2
     assert np.all(model.coefficients()[0][:4] == 0)
     assert np.all(model.coefficients()[0][5:] == 0)

--- a/test/test_pysindy.py
+++ b/test/test_pysindy.py
@@ -22,6 +22,7 @@ from sklearn.model_selection import RandomizedSearchCV
 from sklearn.model_selection import TimeSeriesSplit
 from sklearn.utils.validation import check_is_fitted
 
+from pysindy import pysindy
 from pysindy import SINDy
 from pysindy.differentiation import SINDyDerivative
 from pysindy.differentiation import SmoothedFiniteDifference
@@ -434,6 +435,14 @@ def test_score_discrete_time(data_discrete_time):
     model.fit(x)
     assert model.score(x) > 0.75
     assert model.score(x, x_dot=x) < 1
+
+
+def test_bad_multiple_trajectories(data_multiple_trajectories):
+    x, t = data_multiple_trajectories
+    with pytest.raises(TypeError):
+        pysindy._check_multiple_trajectories(x, x_dot=x[0], u=None)
+    with pytest.raises(ValueError):
+        pysindy._check_multiple_trajectories(x, x_dot=x[:-1], u=None)
 
 
 def test_fit_discrete_time_multiple_trajectories(

--- a/test/test_pysindy.py
+++ b/test/test_pysindy.py
@@ -330,66 +330,54 @@ def test_score_pde(data_1d_random_pde):
     assert model.score(u, t) <= 1
 
 
-def test_fit_multiple_trajectores(data_multiple_trajctories):
-    x, t = data_multiple_trajctories
+def test_fit_multiple_trajectores(data_multiple_trajectories):
+    x, t = data_multiple_trajectories
     model = SINDy()
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.fit(x, t=t)
-
-    model.fit(x, multiple_trajectories=True)
+    model.fit(x)
     check_is_fitted(model)
 
-    model.fit(x, t=t, multiple_trajectories=True)
-    assert model.score(x, t=t, multiple_trajectories=True) > 0.8
+    model.fit(x, t=t)
+    assert model.score(x, t=t) > 0.8
 
     model = SINDy()
-    model.fit(x, x_dot=x, multiple_trajectories=True)
+    model.fit(x, x_dot=x)
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x, t=t, x_dot=x, multiple_trajectories=True)
+    model.fit(x, t=t, x_dot=x)
     check_is_fitted(model)
 
     # Test validate_input
     t[0] = None
     with pytest.raises(ValueError):
-        model.fit(x, t=t, multiple_trajectories=True)
+        model.fit(x, t=t)
 
 
-def test_predict_multiple_trajectories(data_multiple_trajctories):
-    x, t = data_multiple_trajctories
+def test_predict_multiple_trajectories(data_multiple_trajectories):
+    x, t = data_multiple_trajectories
     model = SINDy()
-    model.fit(x, t=t, multiple_trajectories=True)
+    model.fit(x, t=t)
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.predict(x)
-
-    p = model.predict(x, multiple_trajectories=True)
+    p = model.predict(x)
     assert len(p) == len(x)
 
 
-def test_score_multiple_trajectories(data_multiple_trajctories):
-    x, t = data_multiple_trajctories
+def test_score_multiple_trajectories(data_multiple_trajectories):
+    x, t = data_multiple_trajectories
     model = SINDy()
-    model.fit(x, t=t, multiple_trajectories=True)
+    model.fit(x, t=t)
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.score(x)
-
-    s = model.score(x, multiple_trajectories=True)
+    s = model.score(x)
     assert s <= 1
 
-    s = model.score(x, t=t, multiple_trajectories=True)
+    s = model.score(x, t=t)
     assert s <= 1
 
-    s = model.score(x, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, x_dot=x)
     assert s <= 1
 
-    s = model.score(x, t=t, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, t=t, x_dot=x)
     assert s <= 1
 
 
@@ -449,17 +437,12 @@ def test_fit_discrete_time_multiple_trajectories(
     data_discrete_time_multiple_trajectories,
 ):
     x = data_discrete_time_multiple_trajectories
-
-    # Should fail if multiple_trajectories flag is not set
     model = SINDy(discrete_time=True)
-    with pytest.raises(ValueError):
-        model.fit(x)
-
-    model.fit(x, multiple_trajectories=True)
+    model.fit(x)
     check_is_fitted(model)
 
     model = SINDy(discrete_time=True)
-    model.fit(x, x_dot=x, multiple_trajectories=True)
+    model.fit(x, x_dot=x)
     check_is_fitted(model)
 
 
@@ -468,13 +451,9 @@ def test_predict_discrete_time_multiple_trajectories(
 ):
     x = data_discrete_time_multiple_trajectories
     model = SINDy(discrete_time=True)
-    model.fit(x, multiple_trajectories=True)
+    model.fit(x)
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.predict(x)
-
-    y = model.predict(x, multiple_trajectories=True)
+    y = model.predict(x)
     assert len(y) == len(x)
 
 
@@ -483,17 +462,13 @@ def test_score_discrete_time_multiple_trajectories(
 ):
     x = data_discrete_time_multiple_trajectories
     model = SINDy(discrete_time=True)
-    model.fit(x, multiple_trajectories=True)
+    model.fit(x)
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.score(x)
-
-    s = model.score(x, multiple_trajectories=True)
+    s = model.score(x)
     assert s > 0.75
 
     # x is not its own derivative, so we expect bad performance here
-    s = model.score(x, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, x_dot=x)
     assert s < 1
 
 
@@ -534,7 +509,7 @@ def test_print_discrete_time_multiple_trajectories(
 ):
     x = data_discrete_time_multiple_trajectories
     model = SINDy(discrete_time=True)
-    model.fit(x, multiple_trajectories=True)
+    model.fit(x)
 
     model.print()
 
@@ -542,14 +517,14 @@ def test_print_discrete_time_multiple_trajectories(
     assert len(out) > 1
 
 
-def test_differentiate(data_lorenz, data_multiple_trajctories):
+def test_differentiate(data_lorenz, data_multiple_trajectories):
     x, t = data_lorenz
 
     model = SINDy()
     model.differentiate(x, t)
 
-    x, t = data_multiple_trajctories
-    model.differentiate(x, t, multiple_trajectories=True)
+    x, t = data_multiple_trajectories
+    model.differentiate(x, t)
 
     model = SINDy(discrete_time=True)
     with pytest.raises(RuntimeError):
@@ -686,34 +661,34 @@ def test_multiple_trajectories_and_ensemble(diffuse_multiple_trajectories):
 
     optimizer = STLSQ(threshold=0.1, alpha=1e-5, normalize_columns=False)
     model = SINDy(feature_library=pde_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, multiple_trajectories=True, t=t)
+    model.fit(u, t=t)
     print(model.coefficients(), model.coefficients()[0][-1])
     assert abs(model.coefficients()[0][-1] - 1) < 1e-2
     assert np.all(model.coefficients()[0][:-1] == 0)
 
     model = SINDy(feature_library=weak_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, multiple_trajectories=True, t=t)
+    model.fit(u, t=t)
     assert abs(model.coefficients()[0][-1] - 1) < 1e-2
     assert np.all(model.coefficients()[0][:-1] == 0)
 
     optimizer = EnsembleOptimizer(opt=optimizer, bagging=True, n_subset=len(t))
 
     model = SINDy(feature_library=pde_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, multiple_trajectories=True, t=t)
+    model.fit(u, t=t)
     assert abs(model.coefficients()[0][-1] - 1) < 1e-2
     assert np.all(model.coefficients()[0][:-1] == 0)
 
     model = SINDy(feature_library=weak_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, multiple_trajectories=True, t=t)
+    model.fit(u, t=t)
     assert abs(model.coefficients()[0][-1] - 1) < 1e-2
     assert np.all(model.coefficients()[0][:-1] == 0)
 
     model = SINDy(feature_library=pde_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, multiple_trajectories=True, t=t)
+    model.fit(u, t=t)
     assert abs(model.coefficients()[0][-1] - 1) < 1e-2
     assert np.all(model.coefficients()[0][:-1] == 0)
 
     model = SINDy(feature_library=weak_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, multiple_trajectories=True, t=t)
+    model.fit(u, t=t)
     assert abs(model.coefficients()[0][-1] - 1) < 1e-2
     assert np.all(model.coefficients()[0][:-1] == 0)

--- a/test/test_sindyc.py
+++ b/test/test_sindyc.py
@@ -235,78 +235,55 @@ def test_score(data):
     assert model.score(x, u=u, t=t, x_dot=x) <= 1
 
 
-def test_fit_multiple_trajectores(data_multiple_trajctories):
-    x, t = data_multiple_trajctories
+def test_fit_multiple_trajectores(data_multiple_trajectories):
+    x, t = data_multiple_trajectories
     u = [np.ones((xi.shape[0], 2)) for xi in x]
 
     model = SINDy()
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.fit(x, u=u, t=t)
-
-    # Should fail if x or u is not a list
-    with pytest.raises(TypeError):
-        model.fit(x, u=u[0], multiple_trajectories=True)
-
-    with pytest.raises(TypeError):
-        model.fit(x[0], u=u, multiple_trajectories=True)
-
-    # x and u should be lists of the same length
-    with pytest.raises(ValueError):
-        model.fit(x[:-1], u=u, multiple_trajectories=True)
-
-    model.fit(x, u=u, multiple_trajectories=True)
+    model.fit(x, u=u)
     check_is_fitted(model)
 
-    model.fit(x, u=u, t=t, multiple_trajectories=True)
-    assert model.score(x, u=u, t=t, multiple_trajectories=True) > 0.8
+    model.fit(x, u=u, t=t)
+    assert model.score(x, u=u, t=t) > 0.8
 
     model = SINDy()
-    model.fit(x, u=u, x_dot=x, multiple_trajectories=True)
+    model.fit(x, u=u, x_dot=x)
     check_is_fitted(model)
 
     model = SINDy()
-    model.fit(x, u=u, t=t, x_dot=x, multiple_trajectories=True)
+    model.fit(x, u=u, t=t, x_dot=x)
     check_is_fitted(model)
 
 
-def test_predict_multiple_trajectories(data_multiple_trajctories):
-    x, t = data_multiple_trajctories
+def test_predict_multiple_trajectories(data_multiple_trajectories):
+    x, t = data_multiple_trajectories
     u = [np.ones((xi.shape[0], 2)) for xi in x]
 
     model = SINDy()
-    model.fit(x, u=u, t=t, multiple_trajectories=True)
+    model.fit(x, u=u, t=t)
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.predict(x, u=u)
-
-    p = model.predict(x, u=u, multiple_trajectories=True)
+    p = model.predict(x, u=u)
     assert len(p) == len(x)
 
 
-def test_score_multiple_trajectories(data_multiple_trajctories):
-    x, t = data_multiple_trajctories
+def test_score_multiple_trajectories(data_multiple_trajectories):
+    x, t = data_multiple_trajectories
     u = [np.ones((xi.shape[0], 2)) for xi in x]
 
     model = SINDy()
-    model.fit(x, u=u, t=t, multiple_trajectories=True)
+    model.fit(x, u=u, t=t)
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.score(x, u=u)
-
-    s = model.score(x, u=u, multiple_trajectories=True)
+    s = model.score(x, u=u)
     assert s <= 1
 
-    s = model.score(x, u=u, t=t, multiple_trajectories=True)
+    s = model.score(x, u=u, t=t)
     assert s <= 1
 
-    s = model.score(x, u=u, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u, x_dot=x)
     assert s <= 1
 
-    s = model.score(x, u=u, t=t, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u, t=t, x_dot=x)
     assert s <= 1
 
 
@@ -382,17 +359,12 @@ def test_fit_discrete_time_multiple_trajectories(
     data_discrete_time_multiple_trajectories_c,
 ):
     x, u = data_discrete_time_multiple_trajectories_c
-
-    # Should fail if multiple_trajectories flag is not set
     model = SINDy(discrete_time=True)
-    with pytest.raises(ValueError):
-        model.fit(x, u=u)
-
-    model.fit(x, u=u, multiple_trajectories=True)
+    model.fit(x, u=u)
     check_is_fitted(model)
 
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u, x_dot=x, multiple_trajectories=True)
+    model.fit(x, u=u, x_dot=x)
     check_is_fitted(model)
 
 
@@ -401,13 +373,9 @@ def test_predict_discrete_time_multiple_trajectories(
 ):
     x, u = data_discrete_time_multiple_trajectories_c
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u, multiple_trajectories=True)
+    model.fit(x, u=u)
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.predict(x, u=u)
-
-    y = model.predict(x, u=u, multiple_trajectories=True)
+    y = model.predict(x, u=u)
     assert len(y) == len(x)
 
 
@@ -416,17 +384,13 @@ def test_score_discrete_time_multiple_trajectories(
 ):
     x, u = data_discrete_time_multiple_trajectories_c
     model = SINDy(discrete_time=True)
-    model.fit(x, u=u, multiple_trajectories=True)
+    model.fit(x, u=u)
 
-    # Should fail if multiple_trajectories flag is not set
-    with pytest.raises(ValueError):
-        model.score(x, u=u)
-
-    s = model.score(x, u=u, multiple_trajectories=True)
+    s = model.score(x, u=u)
     assert s > 0.75
 
     # x is not its own derivative, so we expect bad performance here
-    s = model.score(x, u=u, x_dot=x, multiple_trajectories=True)
+    s = model.score(x, u=u, x_dot=x)
     assert s < 1
 
 

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -1,6 +1,9 @@
 import numpy as np
+import pytest
 
+from pysindy.utils import AxesArray
 from pysindy.utils import reorder_constraints
+from pysindy.utils import validate_control_variables
 
 
 def test_reorder_constraints_1D():
@@ -26,3 +29,17 @@ def test_reorder_constraints_2D():
     np.testing.assert_array_equal(
         reorder_constraints(row_order, n_feats, output_order="target"), target_order
     )
+
+
+def test_validate_controls():
+    with pytest.raises(ValueError):
+        validate_control_variables(1, [])
+    with pytest.raises(ValueError):
+        validate_control_variables([], 1)
+    with pytest.raises(ValueError):
+        validate_control_variables([], [1])
+    arr = AxesArray(np.ones(4).reshape((2, 2)), axes={"ax_time": 0, "ax_coord": 1})
+    with pytest.raises(ValueError):
+        validate_control_variables([arr], [arr[:1]])
+    u_mod = validate_control_variables([arr], [arr], trim_last_point=True)
+    assert u_mod[0].n_time == 1


### PR DESCRIPTION
For your consideration, here's a PR that implements #353.

tl;dr: IMO the `multiple_trajectories` argument is unneccessary and its removal simplifies calling signatures.  `SINDy.fit()` knows users want multiple trajectories when they pass a list of arrays - the same way many numpy functions have implicit behavior when passed a list of arrays instead of a single array.  OTOH, there exists a niche case where someone calls `fit()` with `x` as a list instead of an array and `t` as a float.  Previously, this would give an error, while in this PR, it would be allowed, similar to how submitting transposed data is allowed but doesn't give people what they think.  If people desire, I can add guard code around specifically this case, but my feeling is that the docstring is clear and the edge case may not exist in the wild.