### PR TITLE
Even faster tests :smoking: 

### DIFF
--- a/pysindy/optimizers/stable_linear_sr3.py
+++ b/pysindy/optimizers/stable_linear_sr3.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Tuple
 
 try:
     import cvxpy as cp
@@ -204,7 +205,7 @@ class StableLinearSR3(ConstrainedSR3):
         y: np.ndarray,
         coef_sparse: np.ndarray,
         coef_neg_def: np.ndarray,
-    ) -> tuple[cp.Variable, cp.Expression]:
+    ) -> Tuple[cp.Variable, cp.Expression]:
         xi = cp.Variable(coef_sparse.shape[0] * coef_sparse.shape[1])
         cost = cp.sum_squares(x @ xi - y.flatten())
         cost = cost + cp.sum_squares(xi - coef_neg_def.flatten()) / (2 * self.nu)

--- a/pysindy/optimizers/stable_linear_sr3.py
+++ b/pysindy/optimizers/stable_linear_sr3.py
@@ -311,40 +311,24 @@ class StableLinearSR3(ConstrainedSR3):
             assert trimming_array is not None
             R2 *= trimming_array.reshape(x.shape[0], 1)
 
-        if self.thresholds is None:
-            regularization = self.reg(
-                coef_negative_definite, self.threshold**2 / self.nu
+        regularization = self.reg(
+            coef_negative_definite,
+            (self.threshold**2 if self.thresholds is None else self.thresholds**2)
+            / self.nu,
+        )
+        if print_ind == 0 and self.verbose:
+            row = [
+                q,
+                np.sum(R2),
+                np.sum(D2) / self.nu,
+                regularization,
+                np.sum(R2) + np.sum(D2) + regularization,
+            ]
+            print(
+                "{0:10d} ... {1:10.4e} ... {2:10.4e} ... {3:10.4e}"
+                " ... {4:10.4e}".format(*row)
             )
-            if print_ind == 0 and self.verbose:
-                row = [
-                    q,
-                    np.sum(R2),
-                    np.sum(D2) / self.nu,
-                    regularization,
-                    np.sum(R2) + np.sum(D2) + regularization,
-                ]
-                print(
-                    "{0:10d} ... {1:10.4e} ... {2:10.4e} ... {3:10.4e}"
-                    " ... {4:10.4e}".format(*row)
-                )
-            return 0.5 * np.sum(R2) + 0.5 * regularization + 0.5 * np.sum(D2) / self.nu
-        else:
-            regularization = self.reg(
-                coef_negative_definite, self.thresholds**2 / self.nu
-            )
-            if print_ind == 0 and self.verbose:
-                row = [
-                    q,
-                    np.sum(R2),
-                    np.sum(D2) / self.nu,
-                    regularization,
-                    np.sum(R2) + np.sum(D2) + regularization,
-                ]
-                print(
-                    "{0:10d} ... {1:10.4e} ... {2:10.4e} ... {3:10.4e}"
-                    " ... {4:10.4e}".format(*row)
-                )
-            return 0.5 * np.sum(R2) + 0.5 * regularization + 0.5 * np.sum(D2) / self.nu
+        return 0.5 * np.sum(R2) + 0.5 * regularization + 0.5 * np.sum(D2) / self.nu
 
     def _reduce(self, x, y):
         """

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Tuple
 
 import cvxpy as cp
 import numpy as np
@@ -498,7 +499,7 @@ class TrappingSR3(SR3):
 
     def _create_var_and_part_cost(
         self, var_len: int, x_expanded: np.ndarray, y: np.ndarray
-    ) -> tuple[cp.Variable, cp.Expression]:
+    ) -> Tuple[cp.Variable, cp.Expression]:
         xi = cp.Variable(var_len)
         cost = cp.sum_squares(x_expanded @ xi - y.flatten())
         if self.thresholder.lower() == "l1":

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -314,11 +314,6 @@ class TrappingSR3(SR3):
         self.tol_m = tol_m
         self.accel = accel
         self.verbose_cvxpy = verbose_cvxpy
-        self.A_history_ = []
-        self.m_history_ = []
-        self.PW_history_ = []
-        self.PWeigs_history_ = []
-        self.history_ = []
         self.objective_history = objective_history
         self.unbias = False
         self.use_constraints = (constraint_lhs is not None) and (
@@ -437,7 +432,7 @@ class TrappingSR3(SR3):
         # If PL/PQ finite and correct, so trapping theorem is being used,
         # then make sure library is quadratic and correct shape
         if (np.any(self.PL_ != 0.0) or np.any(self.PQ_ != 0.0)) and n_features != N:
-            print(
+            warnings.warn(
                 "The feature library is the wrong shape or not quadratic, "
                 "so please correct this if you are attempting to use the "
                 "trapping algorithm with the stability term included. Setting "
@@ -690,7 +685,11 @@ class TrappingSR3(SR3):
         TrappingSR3 algorithm.
         Assumes initial guess for coefficients is stored in ``self.coef_``.
         """
-
+        self.A_history_ = []
+        self.m_history_ = []
+        self.PW_history_ = []
+        self.PWeigs_history_ = []
+        self.history_ = []
         n_samples, n_features = x.shape
         r = y.shape[1]
         N = int((r**2 + 3 * r) / 2.0)

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -502,9 +502,10 @@ class TrappingSR3(SR3):
             )
         return 0.5 * np.sum(R2) + 0.5 * np.sum(A2) / self.eta + L1
 
-    def _solve_sparse_relax_and_split(self, r, N, x_expanded, y, Pmatrix, A, coef_prev):
-        """Solve coefficient update with CVXPY if threshold != 0"""
-        xi = cp.Variable(N * r)
+    def _create_var_and_part_cost(
+        self, var_len: int, x_expanded: np.ndarray, y: np.ndarray
+    ) -> tuple[cp.Variable, cp.Expression]:
+        xi = cp.Variable(var_len)
         cost = cp.sum_squares(x_expanded @ xi - y.flatten())
         if self.thresholder.lower() == "l1":
             cost = cost + self.threshold * cp.norm1(xi)
@@ -514,6 +515,11 @@ class TrappingSR3(SR3):
             cost = cost + self.threshold * cp.norm2(xi) ** 2
         elif self.thresholder.lower() == "weighted_l2":
             cost = cost + cp.norm2(np.ravel(self.thresholds) @ xi) ** 2
+        return xi, cost
+
+    def _solve_sparse_relax_and_split(self, r, N, x_expanded, y, Pmatrix, A, coef_prev):
+        """Solve coefficient update with CVXPY if threshold != 0"""
+        xi, cost = self._create_var_and_part_cost(N * r, x_expanded, y)
         cost = cost + cp.sum_squares(Pmatrix @ xi - A.flatten()) / self.eta
         if self.use_constraints:
             if self.inequality_constraints:
@@ -612,16 +618,7 @@ class TrappingSR3(SR3):
         problem, solved in CVXPY, so convergence/quality guarantees are
         not available here!
         """
-        xi = cp.Variable(N * r)
-        cost = cp.sum_squares(x_expanded @ xi - y.flatten())
-        if self.thresholder.lower() == "l1":
-            cost = cost + self.threshold * cp.norm1(xi)
-        elif self.thresholder.lower() == "weighted_l1":
-            cost = cost + cp.norm1(np.ravel(self.thresholds) @ xi)
-        elif self.thresholder.lower() == "l2":
-            cost = cost + self.threshold * cp.norm2(xi) ** 2
-        elif self.thresholder.lower() == "weighted_l2":
-            cost = cost + cp.norm2(np.ravel(self.thresholds) @ xi) ** 2
+        xi, cost = self._create_var_and_part_cost(N * r, x_expanded, y)
         cost = cost + cp.lambda_max(cp.reshape(Pmatrix @ xi, (r, r))) / self.eta
         if self.use_constraints:
             if self.inequality_constraints:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,14 +46,14 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="session")
 def data_1d():
-    t = np.linspace(0, 5, 100)
+    t = np.linspace(0, 1, 10)
     x = 2 * t.reshape(-1, 1)
     return x, t
 
 
 @pytest.fixture(scope="session")
 def data_1d_bad_shape():
-    t = np.linspace(0, 5, 100)
+    t = np.linspace(0, 5, 10)
     x = 2 * t
     return x, t
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -97,10 +97,10 @@ def diffuse_multiple_trajectories():
 
     # Required for accurate solve_ivp results
     integrator_keywords = {}
-    integrator_keywords["rtol"] = 1e-12
+    integrator_keywords["rtol"] = 1e-8
     integrator_keywords["method"] = "LSODA"
-    integrator_keywords["atol"] = 1e-12
-    N = 200
+    integrator_keywords["atol"] = 1e-8
+    N = 25
     h0 = 1.0
     L = 5
     T = 1
@@ -110,17 +110,11 @@ def diffuse_multiple_trajectories():
     y0 = np.reshape(
         h0 + ep * np.cos(4 * np.pi / L * x) + ep * np.cos(2 * np.pi / L * x), N
     )
-    y1 = np.reshape(
-        h0 + ep * np.cos(4 * np.pi / L * x) - ep * np.cos(2 * np.pi / L * x), N
-    )
     dx = x[1] - x[0]
     sol1 = solve_ivp(
         diffuse, (t[0], t[-1]), y0=y0, t_eval=t, args=(dx, N), **integrator_keywords
     )
-    sol2 = solve_ivp(
-        diffuse, (t[0], t[-1]), y0=y1, t_eval=t, args=(dx, N), **integrator_keywords
-    )
-    u = [np.reshape(sol1.y, (N, N, 1)), np.reshape(sol2.y, (N, N, 1))]
+    u = [np.reshape(sol1.y, (N, N, 1))]
     return t, x, u
 
 

--- a/test/test_feature_library.py
+++ b/test/test_feature_library.py
@@ -202,7 +202,7 @@ def test_generalized_library_bad_parameters(data_lorenz, params):
         dict(parameter_library=None),
     ],
 )
-def test_parametrized_library_bad_parameters(data_lorenz, params):
+def test_parameterized_library_bad_parameters(data_lorenz, params):
     with pytest.raises(ValueError):
         lib = ParameterizedLibrary(**params)
         x, t = data_lorenz

--- a/test/test_feature_library.py
+++ b/test/test_feature_library.py
@@ -661,18 +661,18 @@ def test_parameterized_library(diffuse_multiple_trajectories):
         feature_library=pde_lib, optimizer=optimizer, feature_names=["u", "c"]
     )
     model.fit(xs, u=us, t=t)
-    assert abs(model.coefficients()[0][4] - 1) < 1e-2
-    assert np.all(model.coefficients()[0][:4] == 0)
-    assert np.all(model.coefficients()[0][5:] == 0)
+    assert abs(model.coefficients()[0, 4] - 1) < 1e-1
+    assert np.all(model.coefficients()[0, :4] == 0)
+    assert np.all(model.coefficients()[0, 5:] == 0)
 
-    optimizer = STLSQ(threshold=0.5, alpha=1e-8, normalize_columns=False)
+    optimizer = STLSQ(threshold=0.25, alpha=1e-8, normalize_columns=False)
     model = SINDy(
         feature_library=weak_lib, optimizer=optimizer, feature_names=["u", "c"]
     )
     model.fit(xs, u=us, t=t)
-    assert abs(model.coefficients()[0][4] - 1) < 1e-2
-    assert np.all(model.coefficients()[0][:4] == 0)
-    assert np.all(model.coefficients()[0][5:] == 0)
+    assert abs(model.coefficients()[0, 4] - 1) < 1e-1
+    assert np.all(model.coefficients()[0, :4] == 0)
+    assert np.all(model.coefficients()[0, 5:] == 0)
 
 
 # Helper function for testing PDE libraries

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -163,17 +163,14 @@ def test_alternate_parameters(data_derivative_1d, kwargs):
         MIOSR,
     ],
 )
-def test_sample_weight_optimizers(data_lorenz, optimizer):
-    x, t = data_lorenz
-    dt = t[1] - t[0]
-    x_dot = FiniteDifference()._differentiate(x, t=dt)
+def test_sample_weight_optimizers(data_1d, optimizer):
+    x, t = data_1d
 
     sample_weight = np.ones(x[:, 0].shape)
     sample_weight[::2] = 0
-    model = optimizer()
-    model.fit(x, x_dot)
-    model.fit(x, x_dot, sample_weight=sample_weight)
-    check_is_fitted(model)
+    opt = optimizer()
+    opt.fit(x, x, sample_weight=sample_weight)
+    check_is_fitted(opt)
 
 
 @pytest.mark.parametrize("optimizer", [STLSQ, SR3, ConstrainedSR3, StableLinearSR3])
@@ -1055,13 +1052,11 @@ def test_ssr_criteria(data_lorenz):
         MIOSR,
     ],
 )
-def test_optimizers_verbose(data_lorenz, optimizer):
-    x, t = data_lorenz
-    dt = t[1] - t[0]
-    x_dot = FiniteDifference()._differentiate(x, t=dt)
-    model = optimizer(verbose=True)
-    model.fit(x, x_dot)
-    check_is_fitted(model)
+def test_optimizers_verbose(data_1d, optimizer):
+    x, _ = data_1d
+    opt = optimizer(verbose=True)
+    opt.fit(x, x)
+    check_is_fitted(opt)
 
 
 @pytest.mark.parametrize(
@@ -1073,14 +1068,12 @@ def test_optimizers_verbose(data_lorenz, optimizer):
         TrappingSR3,
     ],
 )
-def test_optimizers_verbose_cvxpy(data_lorenz, optimizer):
-    x, t = data_lorenz
-    dt = t[1] - t[0]
-    x_dot = FiniteDifference()._differentiate(x, t=dt)
+def test_optimizers_verbose_cvxpy(data_1d, optimizer):
+    x, _ = data_1d
 
-    model = optimizer(verbose_cvxpy=True)
-    model.fit(x, x_dot)
-    check_is_fitted(model)
+    opt = optimizer(verbose_cvxpy=True)
+    opt.fit(x, x)
+    check_is_fitted(opt)
 
 
 def test_frols_error_linear_dependence():

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -893,19 +893,31 @@ def test_constrained_inequality_constraints(data_lorenz, params):
 @pytest.mark.parametrize(
     "params",
     [
-        dict(thresholder="l1", threshold=0.0005),
-        dict(thresholder="weighted_l1", thresholds=0.0005 * np.ones((3, 9))),
-        dict(thresholder="l2", threshold=0.0005),
-        dict(thresholder="weighted_l2", thresholds=0.0005 * np.ones((3, 9))),
+        dict(thresholder="l1", threshold=2, expected=2.5),
+        dict(thresholder="weighted_l1", thresholds=0.5 * np.ones((1, 2)), expected=1.0),
+        dict(thresholder="l2", threshold=2, expected=1.5),
+        dict(
+            thresholder="weighted_l2", thresholds=0.5 * np.ones((1, 2)), expected=0.75
+        ),
     ],
 )
-def test_trapping_inequality_constraints(data_lorenz, params):
-    x, t = data_lorenz
-    constraint_rhs = np.array([-10.0, 28.0])
-    constraint_matrix = np.zeros((2, 27))
-    constraint_matrix[0, 0] = 1.0
-    constraint_matrix[1, 10] = 1.0
-    feature_names = ["x", "y", "z"]
+def test_trapping_cost_function(params):
+    expected = params.pop("expected")
+    opt = TrappingSR3(inequality_constraints=True, relax_optim=True, **params)
+    x = np.eye(2)
+    y = np.ones(2)
+    xi, cost = opt._create_var_and_part_cost(2, x, y)
+    xi.value = np.array([0.5, 0.5])
+    np.testing.assert_allclose(cost.value, expected)
+
+
+def test_trapping_inequality_constraints():
+    t = np.arange(0, 1, 0.1)
+    x = np.stack((t, t**2)).T
+    y = x[:, 0] + 0.1 * x[:, 1]
+    constraint_rhs = np.array([0.1])
+    constraint_matrix = np.zeros((1, 2))
+    constraint_matrix[0, 1] = 0.1
 
     # Run Trapping SR3 without CVXPY for the m solve
     opt = TrappingSR3(
@@ -914,18 +926,9 @@ def test_trapping_inequality_constraints(data_lorenz, params):
         constraint_order="feature",
         inequality_constraints=True,
         relax_optim=True,
-        **params,
     )
-    poly_lib = PolynomialLibrary(degree=2, include_bias=False)
-    model = SINDy(
-        optimizer=opt,
-        feature_library=poly_lib,
-        feature_names=feature_names,
-    )
-    model.fit(x, t=t[1] - t[0])
-    # This sometimes fails with L2 norm so just check the model is fitted
-    check_is_fitted(model)
-
+    opt.fit(x, y)
+    assert np.all(np.dot(constraint_matrix, (opt.coef_).flatten()) <= constraint_rhs)
     # Run Trapping SR3 with CVXPY for the m solve
     opt = TrappingSR3(
         constraint_lhs=constraint_matrix,
@@ -933,26 +936,9 @@ def test_trapping_inequality_constraints(data_lorenz, params):
         constraint_order="feature",
         inequality_constraints=True,
         relax_optim=False,
-        **params,
     )
-    model = SINDy(
-        optimizer=opt,
-        feature_library=poly_lib,
-        differentiation_method=FiniteDifference(drop_endpoints=True),
-        feature_names=feature_names,
-    )
-    model.fit(x, t=t[1] - t[0])
-
-    # This sometimes fails with L2 norm or different versions of CVXPY
-    # so just check the model is fitted
-    check_is_fitted(model)
-    # assert np.all(
-    #     np.dot(constraint_matrix, (model.coefficients()).flatten()) <= constraint_rhs
-    # ) or np.allclose(
-    #    np.dot(constraint_matrix, (model.coefficients()).flatten()),
-    #    constraint_rhs,
-    #    atol=1e-3,
-    # )
+    opt.fit(x, y)
+    assert np.all(np.dot(constraint_matrix, (opt.coef_).flatten()) <= constraint_rhs)
 
 
 @pytest.mark.parametrize(

--- a/test/test_pysindy.py
+++ b/test/test_pysindy.py
@@ -31,7 +31,6 @@ from pysindy.feature_library import PDELibrary
 from pysindy.feature_library import PolynomialLibrary
 from pysindy.feature_library import WeakPDELibrary
 from pysindy.optimizers import ConstrainedSR3
-from pysindy.optimizers import EnsembleOptimizer
 from pysindy.optimizers import SR3
 from pysindy.optimizers import STLSQ
 from pysindy.optimizers import WrappedOptimizer
@@ -640,7 +639,7 @@ def test_data_shapes():
     model.fit(x)
 
 
-def test_multiple_trajectories_and_ensemble(diffuse_multiple_trajectories):
+def test_diffusion_pde(diffuse_multiple_trajectories):
     t, x, u = diffuse_multiple_trajectories
     library_functions = [lambda x: x]
     library_function_names = [lambda x: x]
@@ -663,36 +662,13 @@ def test_multiple_trajectories_and_ensemble(diffuse_multiple_trajectories):
         K=100,
     )
 
-    optimizer = STLSQ(threshold=0.1, alpha=1e-5, normalize_columns=False)
+    optimizer = STLSQ(threshold=0.2, alpha=1e-5, normalize_columns=False)
     model = SINDy(feature_library=pde_lib, optimizer=optimizer, feature_names=["u"])
     model.fit(u, t=t)
-    print(model.coefficients(), model.coefficients()[0][-1])
-    assert abs(model.coefficients()[0][-1] - 1) < 1e-2
-    assert np.all(model.coefficients()[0][:-1] == 0)
+    assert abs(model.coefficients()[0, -1] - 1) < 1e-1
+    assert np.all(model.coefficients()[0, :-1] == 0)
 
     model = SINDy(feature_library=weak_lib, optimizer=optimizer, feature_names=["u"])
     model.fit(u, t=t)
-    assert abs(model.coefficients()[0][-1] - 1) < 1e-2
-    assert np.all(model.coefficients()[0][:-1] == 0)
-
-    optimizer = EnsembleOptimizer(opt=optimizer, bagging=True, n_subset=len(t))
-
-    model = SINDy(feature_library=pde_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, t=t)
-    assert abs(model.coefficients()[0][-1] - 1) < 1e-2
-    assert np.all(model.coefficients()[0][:-1] == 0)
-
-    model = SINDy(feature_library=weak_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, t=t)
-    assert abs(model.coefficients()[0][-1] - 1) < 1e-2
-    assert np.all(model.coefficients()[0][:-1] == 0)
-
-    model = SINDy(feature_library=pde_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, t=t)
-    assert abs(model.coefficients()[0][-1] - 1) < 1e-2
-    assert np.all(model.coefficients()[0][:-1] == 0)
-
-    model = SINDy(feature_library=weak_lib, optimizer=optimizer, feature_names=["u"])
-    model.fit(u, t=t)
-    assert abs(model.coefficients()[0][-1] - 1) < 1e-2
-    assert np.all(model.coefficients()[0][:-1] == 0)
+    assert abs(model.coefficients()[0, -1] - 1) < 1e-1
+    assert np.all(model.coefficients()[0, :-1] == 0)


### PR DESCRIPTION
Took the :microscope: to the slowest tests of `StableLinearSR3` and `TrappingSR3`.  Since test parameterization affected only the creation of CVXPY functions, I refactored that part out to speed up tests.

This drops test time from around 45 sec to ~30~ 14 sec

Closes #320

@akaptano, if you get a chance to review, that would be great, since this mostly affects your code.
Edit: @znicolaou, I made all the changes to Weak/PDE library tests here too.