### PR TITLE
DOC: Add requirements for type annotations to readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,3 +10,6 @@ python:
       path: .
       extra_requirements:
         - docs
+        - cvxpy
+        - miosr
+        - dev


### PR DESCRIPTION
Current docs [fail to build](https://readthedocs.org/projects/pysindy/builds/21702823/) on RTFD because I added type annotations to Trapping.  We normally allow skipping the import of Trapping if `cvxpy` isn't installed, but RTFD needs to import it to understand the docstrings.