### PR TITLE
Make TrappingSR3 a subclass of ConstrainedSR3

### DIFF
--- a/pysindy/optimizers/base.py
+++ b/pysindy/optimizers/base.py
@@ -97,17 +97,24 @@ class BaseOptimizer(LinearRegression, ComplexityMixin):
         unbias: bool = True,
     ):
         super().__init__(fit_intercept=False, copy_X=copy_X)
-
-        if max_iter <= 0:
-            raise ValueError("max_iter must be positive")
-
         self.max_iter = max_iter
         self.iters = 0
-        if np.ndim(initial_guess) == 1:
-            initial_guess = initial_guess.reshape(1, -1)
         self.initial_guess = initial_guess
         self.normalize_columns = normalize_columns
         self.unbias = unbias
+        self.__post_init_guard()
+
+    # See name mangling rules for double underscore rationale
+    def __post_init_guard(self):
+        """Conduct initialization post-init, as required by scikitlearn API."""
+        if np.ndim(self.initial_guess) == 1:
+            self.initial_guess = self.initial_guess.reshape(1, -1)
+        if self.max_iter <= 0:
+            raise ValueError("max_iter must be positive")
+
+    def set_params(self, **kwargs):
+        super().set_params(**kwargs)
+        self.__post_init_guard
 
     # Force subclasses to implement this
     @abc.abstractmethod

--- a/pysindy/optimizers/constrained_sr3.py
+++ b/pysindy/optimizers/constrained_sr3.py
@@ -478,9 +478,8 @@ class ConstrainedSR3(SR3):
                     break
             else:
                 warnings.warn(
-                    "SR3._reduce did not converge after {} iterations.".format(
-                        self.max_iter
-                    ),
+                    f"ConstrainedSR3 did not converge after {self.max_iter}"
+                    " iterations.",
                     ConvergenceWarning,
                 )
         if self.use_constraints and self.constraint_order.lower() == "target":

--- a/pysindy/optimizers/constrained_sr3.py
+++ b/pysindy/optimizers/constrained_sr3.py
@@ -300,7 +300,7 @@ class ConstrainedSR3(SR3):
         else:
             prob = cp.Problem(cp.Minimize(cost))
 
-        # default solver is OSQP here but switches to ECOS for L2
+        # default solver is SCS/OSQP here but switches to ECOS for L2
         try:
             prob.solve(
                 max_iter=self.max_iter,
@@ -311,9 +311,9 @@ class ConstrainedSR3(SR3):
         # Annoying error coming from L2 norm switching to use the ECOS
         # solver, which uses "max_iters" instead of "max_iter", and
         # similar semantic changes for the other variables.
-        except TypeError:
+        except (TypeError, ValueError):
             try:
-                prob.solve(abstol=tol, reltol=tol, verbose=self.verbose_cvxpy)
+                prob.solve(max_iters=self.max_iter, verbose=self.verbose_cvxpy)
             except cp.error.SolverError:
                 print("Solver failed, setting coefs to zeros")
                 xi.value = np.zeros(var_len)

--- a/pysindy/optimizers/constrained_sr3.py
+++ b/pysindy/optimizers/constrained_sr3.py
@@ -274,10 +274,7 @@ class ConstrainedSR3(SR3):
             cost = cost + cp.norm2(np.ravel(self.thresholds) @ xi) ** 2
         return xi, cost
 
-    def _update_coef_cvxpy(self, x, y, coef_sparse):
-        xi, cost = self._create_var_and_part_cost(
-            coef_sparse.shape[0] * coef_sparse.shape[1], x, y
-        )
+    def _update_coef_cvxpy(self, xi, cost, var_len, x, y, coef_sparse):
         if self.use_constraints:
             if self.inequality_constraints and self.equality_constraints:
                 # Process inequality constraints then equality constraints
@@ -438,7 +435,11 @@ class ConstrainedSR3(SR3):
 
         objective_history = []
         if self.inequality_constraints:
-            coef_sparse = self._update_coef_cvxpy(x_expanded, y, coef_sparse)
+            var_len = coef_sparse.shape[0] * coef_sparse.shape[1]
+            xi, cost = self._create_var_and_part_cost(var_len, x_expanded, y)
+            coef_sparse = self._update_coef_cvxpy(
+                xi, cost, var_len, x_expanded, y, coef_sparse
+            )
             objective_history.append(self._objective(x, y, 0, coef_full, coef_sparse))
         else:
             for k in range(self.max_iter):

--- a/pysindy/optimizers/sr3.py
+++ b/pysindy/optimizers/sr3.py
@@ -342,8 +342,8 @@ class SR3(BaseOptimizer):
         coef_sparse = self.coef_.T
         n_samples, n_features = x.shape
 
+        coef_full = coef_sparse.copy()
         if self.use_trimming:
-            coef_full = coef_sparse.copy()
             trimming_array = np.repeat(1.0 - self.trimming_fraction, n_samples)
             self.history_trimming_ = [trimming_array]
         else:
@@ -392,9 +392,7 @@ class SR3(BaseOptimizer):
                 break
         else:
             warnings.warn(
-                "SR3._reduce did not converge after {} iterations.".format(
-                    self.max_iter
-                ),
+                f"SR3 did not converge after {self.max_iter} iterations.",
                 ConvergenceWarning,
             )
         self.coef_ = coef_sparse.T

--- a/pysindy/optimizers/stable_linear_sr3.py
+++ b/pysindy/optimizers/stable_linear_sr3.py
@@ -415,9 +415,7 @@ class StableLinearSR3(ConstrainedSR3):
                 break
         else:
             warnings.warn(
-                "StableLinearSR3._reduce did not converge after {} iterations.".format(
-                    self.max_iter
-                ),
+                f"StableLinearSR3 did not converge after {self.max_iter} iterations.",
                 ConvergenceWarning,
             )
 

--- a/pysindy/optimizers/stlsq.py
+++ b/pysindy/optimizers/stlsq.py
@@ -203,6 +203,7 @@ class STLSQ(BaseOptimizer):
         n_targets = y.shape[1]
         n_features_selected = np.sum(ind)
         sparse_sub = [np.array(self.sparse_ind)] * y.shape[1]
+        optvar = np.zeros((n_targets, n_features))
 
         # Print initial values for each term in the optimization
         if self.verbose:
@@ -266,9 +267,7 @@ class STLSQ(BaseOptimizer):
                 break
         else:
             warnings.warn(
-                "STLSQ._reduce did not converge after {} iterations.".format(
-                    self.max_iter
-                ),
+                "STLSQ did not converge after {self.max_iter} iterations.",
                 ConvergenceWarning,
             )
         if self.sparse_ind is None:

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -132,6 +132,9 @@ class TrappingSR3(ConstrainedSR3):
                             n_targets, n_targets, n_features)
         Quadratic coefficient part of the P matrix in ||Pw - A||^2
 
+    objective_history_: list
+        History of the objective value at each iteration
+
     Examples
     --------
     >>> import numpy as np
@@ -167,7 +170,6 @@ class TrappingSR3(ConstrainedSR3):
         accel=False,
         m0=None,
         A0=None,
-        objective_history=None,
         **kwargs,
     ):
         super().__init__(
@@ -224,7 +226,6 @@ class TrappingSR3(ConstrainedSR3):
         self.gamma = gamma
         self.tol_m = tol_m
         self.accel = accel
-        self.objective_history = objective_history
 
     def _set_Ptensors(
         self, n_targets: int
@@ -594,4 +595,4 @@ class TrappingSR3(ConstrainedSR3):
             )
 
         self.coef_ = coef_sparse.T
-        self.objective_history = objective_history
+        self.objective_history_ = objective_history

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -5,6 +5,7 @@ from typing import Tuple
 
 import cvxpy as cp
 import numpy as np
+from numpy.typing import NDArray
 from scipy.linalg import cho_factor
 from scipy.linalg import cho_solve
 from sklearn.exceptions import ConvergenceWarning
@@ -47,44 +48,20 @@ class TrappingSR3(ConstrainedSR3):
 
     Parameters
     ----------
-    evolve_w : bool, optional (default True)
+    evolve_w :
         If false, don't update w and just minimize over (m, A)
 
-    eta : float, optional (default 1.0e20)
+    eta :
         Determines the strength of the stability term ||Pw-A||^2 in the
         optimization. The default value is very large so that the
         algorithm default is to ignore the stability term. In this limit,
         this should be approximately equivalent to the ConstrainedSR3 method.
 
-    alpha_m : float, optional (default eta * 0.1)
-        Determines the step size in the prox-gradient descent over m.
-        For convergence, need alpha_m <= eta / ||w^T * PQ^T * PQ * w||.
-        Typically 0.01 * eta <= alpha_m <= 0.1 * eta.
-
-    alpha_A : float, optional (default eta)
-        Determines the step size in the prox-gradient descent over A.
-        For convergence, need alpha_A <= eta, so typically
-        alpha_A = eta is used.
-
-    gamma : float, optional (default 0.1)
-        Determines the negative interval that matrix A is projected onto.
-        For most applications gamma = 0.1 - 1.0 works pretty well.
-
-    tol_m : float, optional (default 1e-5)
-        Tolerance used for determining convergence of the optimization
-        algorithm over m.
-
-    thresholder : string, optional (default 'L1')
-        Regularization function to use. For current trapping SINDy,
-        only the L1 and L2 norms are implemented. Note that other convex norms
-        could be straightforwardly implemented, but L0 requires
-        reformulation because of nonconvexity.
-
-    eps_solver : float, optional (default 1.0e-7)
+    eps_solver :
         If threshold != 0, this specifies the error tolerance in the
-        CVXPY (OSQP) solve. Default is 1.0e-3 in OSQP.
+        CVXPY (OSQP) solve. Default 1.0e-7 (Default is 1.0e-3 in OSQP.)
 
-    relax_optim : bool, optional (default True)
+    relax_optim :
         If relax_optim = True, use the relax-and-split method. If False,
         try a direct minimization on the largest eigenvalue.
 
@@ -92,16 +69,42 @@ class TrappingSR3(ConstrainedSR3):
         If True, relax_optim must be false or relax_optim = True
         AND threshold != 0, so that the CVXPY methods are used.
 
-    accel : bool, optional (default False)
+    alpha_A :
+        Determines the step size in the prox-gradient descent over A.
+        For convergence, need alpha_A <= eta, so default
+        alpha_A = eta is used.
+
+    alpha_m :
+        Determines the step size in the prox-gradient descent over m.
+        For convergence, need alpha_m <= eta / ||w^T * PQ^T * PQ * w||.
+        Typically 0.01 * eta <= alpha_m <= 0.1 * eta.  (default eta * 0.1)
+
+    gamma :
+        Determines the negative interval that matrix A is projected onto.
+        For most applications gamma = 0.1 - 1.0 works pretty well.
+
+    tol_m :
+        Tolerance used for determining convergence of the optimization
+        algorithm over m.
+
+    thresholder :
+        Regularization function to use. For current trapping SINDy,
+        only the L1 and L2 norms are implemented. Note that other convex norms
+        could be straightforwardly implemented, but L0 requires
+        reformulation because of nonconvexity. (default 'L1')
+
+    accel :
         Whether or not to use accelerated prox-gradient descent for (m, A).
+        (default False)
 
-    m0 : np.ndarray, shape (n_targets), optional (default None)
-        Initial guess for vector m in the optimization. Otherwise
-        each component of m is randomly initialized in [-1, 1].
+    m0 :
+        Initial guess for vector m in the optimization. Otherwise each
+        component of m is randomly initialized in [-1, 1]. shape (n_targets),
+        default None.
 
-    A0 : np.ndarray, shape (n_targets, n_targets), optional (default None)
-        Initial guess for vector A in the optimization. Otherwise
-        A is initialized as A = diag(gamma).
+    A0 :
+        Initial guess for vector A in the optimization.  Shape (n_targets, n_targets)
+        Default None, meaning A is initialized as A = diag(gamma).
 
     Attributes
     ----------
@@ -157,19 +160,20 @@ class TrappingSR3(ConstrainedSR3):
 
     def __init__(
         self,
-        evolve_w=True,
-        eps_solver=1e-7,
-        relax_optim=True,
+        *,
+        evolve_w: bool = True,
+        eta: float | None = None,
+        eps_solver: float = 1e-7,
+        relax_optim: bool = True,
         inequality_constraints=False,
-        eta=None,
-        alpha_A=None,
-        alpha_m=None,
-        gamma=-0.1,
-        tol_m=1e-5,
-        thresholder="l1",
-        accel=False,
-        m0=None,
-        A0=None,
+        alpha_A: float | None = None,
+        alpha_m: float | None = None,
+        gamma: float = -0.1,
+        tol_m: float = 1e-5,
+        thresholder: str = "l1",
+        accel: bool = False,
+        m0: NDArray | None = None,
+        A0: NDArray | None = None,
         **kwargs,
     ):
         super().__init__(

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -423,6 +423,7 @@ class TrappingSR3(ConstrainedSR3):
         self.history_ = []
         n_samples, n_features = x.shape
         n_tgts = y.shape[1]
+        var_len = n_features * n_tgts
         n_feat_expected = int((n_tgts**2 + 3 * n_tgts) / 2.0)
 
         # Only relevant if the stability term is turned on.
@@ -494,31 +495,19 @@ class TrappingSR3(ConstrainedSR3):
             if self.relax_optim:
                 if self.threshold > 0.0:
                     # sparse relax_and_split
-                    xi, cost = self._create_var_and_part_cost(
-                        n_features * n_tgts, x_expanded, y
-                    )
-                    cost = cost + cp.sum_squares(Pmatrix @ xi - A.flatten()) / self.eta
-                    coef_sparse = self._update_coef_cvxpy(
-                        xi, cost, n_tgts * n_features, coef_prev, self.eps_solver
+                    coef_sparse = self._update_coef_sparse_rs(
+                        var_len, x_expanded, y, Pmatrix, A, coef_prev
                     )
                 else:
-                    pTp = np.dot(Pmatrix.T, Pmatrix)
-                    H = xTx + pTp / self.eta
-                    P_transpose_A = np.dot(Pmatrix.T, A.flatten())
-                    coef_sparse = self._solve_nonsparse_relax_and_split(
-                        H, xTy, P_transpose_A, coef_prev
+                    coef_sparse = self._update_coef_nonsparse_rs(
+                        Pmatrix, A, coef_prev, xTx, xTy
                     )
                 trap_prev_ctr, trap_ctr, A, tk_prev = self._solve_m_relax_and_split(
                     trap_prev_ctr, trap_ctr, A, coef_sparse, tk_prev
                 )
             else:
-                var_len = n_tgts * n_features
-                xi, cost = self._create_var_and_part_cost(var_len, x_expanded, y)
-                cost += (
-                    cp.lambda_max(cp.reshape(Pmatrix @ xi, (n_tgts, n_tgts))) / self.eta
-                )
-                coef_sparse = self._update_coef_cvxpy(
-                    xi, cost, var_len, coef_prev, self.eps_solver
+                coef_sparse = self._update_coef_direct(
+                    var_len, x_expanded, y, Pmatrix, coef_prev, n_tgts
                 )
                 trap_ctr = self._solve_m_direct(n_tgts, coef_sparse)
 
@@ -556,3 +545,19 @@ class TrappingSR3(ConstrainedSR3):
             )
 
         self.coef_ = coef_sparse.T
+
+    def _update_coef_sparse_rs(self, var_len, x_expanded, y, Pmatrix, A, coef_prev):
+        xi, cost = self._create_var_and_part_cost(var_len, x_expanded, y)
+        cost = cost + cp.sum_squares(Pmatrix @ xi - A.flatten()) / self.eta
+        return self._update_coef_cvxpy(xi, cost, var_len, coef_prev, self.eps_solver)
+
+    def _update_coef_nonsparse_rs(self, Pmatrix, A, coef_prev, xTx, xTy):
+        pTp = np.dot(Pmatrix.T, Pmatrix)
+        H = xTx + pTp / self.eta
+        P_transpose_A = np.dot(Pmatrix.T, A.flatten())
+        return self._solve_nonsparse_relax_and_split(H, xTy, P_transpose_A, coef_prev)
+
+    def _update_coef_direct(self, var_len, x_expanded, y, Pmatrix, coef_prev, n_tgts):
+        xi, cost = self._create_var_and_part_cost(var_len, x_expanded, y)
+        cost += cp.lambda_max(cp.reshape(Pmatrix @ xi, (n_tgts, n_tgts))) / self.eta
+        return self._update_coef_cvxpy(xi, cost, var_len, coef_prev, self.eps_solver)

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -2,6 +2,7 @@ import warnings
 from itertools import combinations_with_replacement as combo_wr
 from itertools import product
 from typing import Tuple
+from typing import Union
 
 import cvxpy as cp
 import numpy as np
@@ -160,18 +161,18 @@ class TrappingSR3(ConstrainedSR3):
     def __init__(
         self,
         *,
-        eta: float | None = None,
+        eta: Union[float, None] = None,
         eps_solver: float = 1e-7,
         relax_optim: bool = True,
         inequality_constraints=False,
-        alpha_A: float | None = None,
-        alpha_m: float | None = None,
+        alpha_A: Union[float, None] = None,
+        alpha_m: Union[float, None] = None,
         gamma: float = -0.1,
         tol_m: float = 1e-5,
         thresholder: str = "l1",
         accel: bool = False,
-        m0: NDArray | None = None,
-        A0: NDArray | None = None,
+        m0: Union[NDArray, None] = None,
+        A0: Union[NDArray, None] = None,
         **kwargs,
     ):
         super().__init__(thresholder=thresholder, **kwargs)

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -544,13 +544,10 @@ class TrappingSR3(ConstrainedSR3):
                 self._m_convergence_criterion() < self.tol_m
                 and self._convergence_criterion() < self.tol
             ):
-                # Could not (further) select important features
                 break
-        if k == self.max_iter - 1:
+        else:
             warnings.warn(
-                "TrappingSR3._reduce did not converge after {} iters.".format(
-                    self.max_iter
-                ),
+                f"TrappingSR3 did not converge after {self.max_iter} iters.",
                 ConvergenceWarning,
             )
 

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -760,17 +760,6 @@ def test_sr3_enable_trimming(optimizer, data_linear_oscillator_corrupted):
 
 
 @pytest.mark.parametrize(
-    "optimizer", [SR3, ConstrainedSR3, StableLinearSR3, TrappingSR3]
-)
-def test_sr3_warn(optimizer, data_linear_oscillator_corrupted):
-    x, x_dot, _ = data_linear_oscillator_corrupted
-    model = optimizer(max_iter=1, tol=1e-10)
-
-    with pytest.warns(ConvergenceWarning):
-        model.fit(x, x_dot)
-
-
-@pytest.mark.parametrize(
     "optimizer",
     [
         STLSQ(max_iter=1),
@@ -783,6 +772,7 @@ def test_sr3_warn(optimizer, data_linear_oscillator_corrupted):
 def test_fit_warn(data_derivative_1d, optimizer):
     x, x_dot = data_derivative_1d
     x = x.reshape(-1, 1)
+    optimizer.max_iter = 0  # normally prohibited in constructor
 
     with pytest.warns(ConvergenceWarning):
         optimizer.fit(x, x_dot)

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -206,13 +206,11 @@ def test_sr3_bad_parameters(optimizer, params):
         dict(eta=1, alpha_m=-1),
         dict(eta=1, alpha_A=-1),
         dict(gamma=1),
-        dict(evolve_w=False, relax_optim=False),
         dict(thresholder="l0"),
         dict(threshold=-1),
         dict(max_iter=0),
         dict(eta=10, alpha_m=20),
         dict(eta=10, alpha_A=20),
-        dict(inequality_constraints=True, evolve_w=False),
         dict(
             constraint_lhs=np.zeros((10, 10)),
             constraint_rhs=np.zeros(10),

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -792,7 +792,10 @@ def test_fit_warn(data_derivative_1d, optimizer):
         optimizer.fit(x, x_dot)
 
 
-@pytest.mark.parametrize("optimizer", [ConstrainedSR3, TrappingSR3, MIOSR])
+@pytest.mark.parametrize(
+    "optimizer",
+    [(ConstrainedSR3, {"max_iter": 80}), (TrappingSR3, {"max_iter": 100}), (MIOSR, {})],
+)
 @pytest.mark.parametrize("target_value", [0, -1, 3])
 def test_row_format_constraints(data_linear_combination, optimizer, target_value):
     # Solution is x_dot = x.dot(np.array([[1, 1, 0], [0, 1, 1]]))
@@ -805,10 +808,11 @@ def test_row_format_constraints(data_linear_combination, optimizer, target_value
     constraint_lhs[0, 0] = 1
     constraint_lhs[1, 3] = 1
 
-    model = optimizer(
+    model = optimizer[0](
         constraint_lhs=constraint_lhs,
         constraint_rhs=constraint_rhs,
         constraint_order="feature",
+        **optimizer[1],
     )
     model.fit(x, x_dot)
 
@@ -818,7 +822,13 @@ def test_row_format_constraints(data_linear_combination, optimizer, target_value
 
 
 @pytest.mark.parametrize(
-    "optimizer", [ConstrainedSR3, StableLinearSR3, TrappingSR3, MIOSR]
+    "optimizer",
+    [
+        (ConstrainedSR3, {"max_iter": 80}),
+        (StableLinearSR3, {}),
+        (TrappingSR3, {"max_iter": 100}),
+        (MIOSR, {}),
+    ],
 )
 @pytest.mark.parametrize("target_value", [0, -1, 3])
 def test_target_format_constraints(data_linear_combination, optimizer, target_value):
@@ -831,7 +841,9 @@ def test_target_format_constraints(data_linear_combination, optimizer, target_va
     constraint_lhs[0, 1] = 1
     constraint_lhs[1, 4] = 1
 
-    model = optimizer(constraint_lhs=constraint_lhs, constraint_rhs=constraint_rhs)
+    model = optimizer[0](
+        constraint_lhs=constraint_lhs, constraint_rhs=constraint_rhs, **optimizer[1]
+    )
     model.fit(x, x_dot)
     np.testing.assert_allclose(model.coef_[:, 1], target_value, atol=1e-8)
 

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -483,7 +483,6 @@ def test_trapping_sr3_quadratic_library(params, trapping_sr3_params, quadratic_l
 
     opt = TrappingSR3(**params)
     opt.fit(features, x_dot)
-    assert opt.PL_unsym_.shape == (1, 1, 1, 2)
     assert opt.PL_.shape == (1, 1, 1, 2)
     assert opt.PQ_.shape == (1, 1, 1, 1, 2)
     check_is_fitted(opt)
@@ -497,7 +496,6 @@ def test_trapping_sr3_quadratic_library(params, trapping_sr3_params, quadratic_l
 
     opt = TrappingSR3(**params)
     opt.fit(features, x_dot)
-    assert opt.PL_unsym_.shape == (1, 1, 1, 2)
     assert opt.PL_.shape == (1, 1, 1, 2)
     assert opt.PQ_.shape == (1, 1, 1, 1, 2)
     check_is_fitted(opt)

--- a/test/test_optimizers_complexity.py
+++ b/test/test_optimizers_complexity.py
@@ -45,7 +45,7 @@ def test_complexity_parameter(
 
     optimizers = [
         WrappedOptimizer(opt_cls(**{reg_name: reg_value}), normalize_columns=True)
-        for reg_value in [10, 1, 0.1, 0.01]
+        for reg_value in [10, 1, 0.1, 0.001]
     ]
 
     for opt in optimizers:


### PR DESCRIPTION
This PR simplifies TrappingSR3, reducing it by about 250 lines.  It changes the base class to `ConstrainedSR3`, deferring all calls to cvxpy to that superclass.  It also makes the main algorithm clearer, so that its easier to see how different initialization arguments affect the choice of math involved (mostly because I couldn't quite understand this from the docstring).  As a related effect, the `_reduce` method more closely matches the algorithm in the paper.

The plan is to eventually utilize superclass for combining and applying constraints, since that class is capable of doing both equality and inequality constraints, which will make it easier to include the constraints and helper functions of example 8 into trapping_sr3.py