### PR TITLE
Trapping constraints

### DIFF
--- a/pysindy/feature_library/polynomial_library.py
+++ b/pysindy/feature_library/polynomial_library.py
@@ -1,7 +1,9 @@
 from itertools import chain
+from math import comb
 from typing import Iterator
 
 import numpy as np
+from numpy.typing import NDArray
 from scipy import sparse
 from sklearn.preprocessing import PolynomialFeatures
 from sklearn.utils.validation import check_is_fitted
@@ -73,8 +75,22 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
 
     @staticmethod
     def _combinations(
-        n_features, degree, include_interaction, interaction_only, include_bias
-    ) -> Iterator[tuple]:
+        n_features: int,
+        degree: int,
+        include_interaction: bool,
+        interaction_only: bool,
+        include_bias: bool,
+    ) -> Iterator[tuple[int, ...]]:
+        """
+        Create selection tuples of input indexes for each polynomail term
+
+        Selection tuple iterates the input indexes present in a single term.
+        For example, (x+y+1)^2 would be in iterator of the tuples:
+        (), (0,), (1,), (0, 0), (0, 1), (1, 1)
+        1    x     y      x^2     x*y     y^2
+
+        Order of terms is preserved regardless of include_interation.
+        """
         if not include_interaction:
             return chain(
                 [()] if include_bias else [],
@@ -93,7 +109,12 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
         )
 
     @property
-    def powers_(self):
+    def powers_(self) -> NDArray[np.dtype("int")]:
+        """
+        The exponents of the polynomial as an array of shape
+        (n_features_out, n_features_in), where each item is the exponent of the
+        jth input variable in the ith polynomial term.
+        """
         check_is_fitted(self)
         combinations = self._combinations(
             n_features=self.n_features_in_,
@@ -208,10 +229,10 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
             )
             if sparse.isspmatrix(x):
                 columns = []
-                for comb in combinations:
-                    if comb:
+                for combo in combinations:
+                    if combo:
                         out_col = 1
-                        for col_idx in comb:
+                        for col_idx in combo:
                             out_col = x[..., col_idx].multiply(out_col)
                         columns.append(out_col)
                     else:
@@ -227,7 +248,36 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
                     ),
                     x.__dict__,
                 )
-                for i, comb in enumerate(combinations):
-                    xp[..., i] = x[..., comb].prod(-1)
+                for i, combo in enumerate(combinations):
+                    xp[..., i] = x[..., combo].prod(-1)
             xp_full = xp_full + [xp]
         return xp_full
+
+
+def n_poly_features(
+    n_in_feat: int,
+    degree: int,
+    include_bias: bool = False,
+    include_interation: bool = True,
+    interaction_only: bool = False,
+) -> int:
+    """Calculate number of polynomial features
+
+    Args:
+        n_in_feat: number of input features, e.g. 3 for x, y, z
+        degree: polynomial degree, e.g. 2 for quadratic
+        include_bias: whether to include a constant term
+        include_interaction: whether to include terms mixing multiple inputs
+        interaction_only: whether to omit terms of x_m * x_n^p for p > 1
+    """
+    if not include_interation and interaction_only:
+        raise ValueError("Cannot set interaction only if include_interaction is False")
+    n_feat = include_bias
+    if not include_interation:
+        return n_feat + n_in_feat * degree
+    for deg in range(1, degree + 1):
+        if interaction_only:
+            n_feat += comb(n_in_feat, deg)
+        else:
+            n_feat += comb(n_in_feat + deg - 1, deg)
+    return n_feat

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -1,6 +1,5 @@
 import warnings
 from itertools import combinations as combo_nr
-from itertools import combinations_with_replacement as combo_wr
 from math import comb
 from typing import Tuple
 

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -822,13 +822,15 @@ class TrappingSR3(SR3):
         self.objective_history = objective_history
 
 
-def _make_constraints(n_tgts: int):
+def _make_constraints(n_tgts: int, **kwargs):
     """Create constraints for the Quadratic terms in TrappingSR3.
 
     These are the constraints from equation 5 of the Trapping SINDy paper.
 
     Args:
         n_tgts: number of coordinates or modes for which you're fitting an ODE.
+        kwargs: Keyword arguments to PolynomialLibrary such as
+            ``include_bias``.
 
     Returns:
         A tuple of the constraint zeros, and a constraint matrix to multiply
@@ -841,7 +843,7 @@ def _make_constraints(n_tgts: int):
         reshaping.
     """
     n_terms = n_poly_features(n_tgts, degree=2, include_bias=False)
-    lib = PolynomialLibrary(2, include_bias=False).fit(np.zeros((1, n_tgts)))
+    lib = PolynomialLibrary(2, **kwargs).fit(np.zeros((1, n_tgts)))
     terms = [(t_ind, exps) for t_ind, exps in enumerate(lib.powers_)]
 
     # index of tgt -> index of its pure quadratic term

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -841,7 +841,8 @@ def _make_constraints(n_tgts: int, **kwargs):
         To get "target" order constraints, transpose axis 1 and 2 before
         reshaping.
     """
-    n_terms = n_poly_features(n_tgts, degree=2, include_bias=False)
+    include_bias = kwargs.get("include_bias", False)
+    n_terms = n_poly_features(n_tgts, degree=2, include_bias=include_bias)
     lib = PolynomialLibrary(2, **kwargs).fit(np.zeros((1, n_tgts)))
     terms = [(t_ind, exps) for t_ind, exps in enumerate(lib.powers_)]
 

--- a/test/test_feature_library.py
+++ b/test/test_feature_library.py
@@ -21,6 +21,7 @@ from pysindy.feature_library import SINDyPILibrary
 from pysindy.feature_library import TensoredLibrary
 from pysindy.feature_library import WeakPDELibrary
 from pysindy.feature_library.base import BaseFeatureLibrary
+from pysindy.feature_library.polynomial_library import n_poly_features
 from pysindy.optimizers import SINDyPI
 from pysindy.optimizers import STLSQ
 
@@ -880,3 +881,6 @@ def test_polynomial_combinations(include_interaction, interaction_only, bias, ex
     )
     result = tuple(sorted(list(combos)))
     assert result == expected
+    assert len(expected) == n_poly_features(
+        2, 2, bias, include_interaction, interaction_only
+    )

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -1135,7 +1135,7 @@ def test_remove_and_decrement():
 
 def test_trapping_constraints():
     # x, y, x^2, xy, y^2
-    constraint_rhs, constraint_lhs = _make_constraints(2)
+    constraint_rhs, constraint_lhs = _make_constraints(2, include_bias=False)
     stable_coefs = np.array([[0, 0, 0, 1, -1], [0, 0, -1, 1, 0]])
     result = np.tensordot(constraint_lhs, stable_coefs, ((1, 2), (1, 0)))
     np.testing.assert_array_equal(constraint_rhs, result)

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -30,6 +30,8 @@ from pysindy.optimizers import STLSQ
 from pysindy.optimizers import TrappingSR3
 from pysindy.optimizers import WrappedOptimizer
 from pysindy.optimizers.stlsq import _remove_and_decrement
+from pysindy.optimizers.trapping_sr3 import _antisymm_triple_constraints
+from pysindy.optimizers.trapping_sr3 import _make_constraints
 from pysindy.utils import supports_multiple_targets
 from pysindy.utils.odes import enzyme
 
@@ -1129,3 +1131,18 @@ def test_remove_and_decrement():
         existing_vals=existing_vals, vals_to_remove=vals_to_remove
     )
     np.testing.assert_array_equal(expected, result)
+
+
+def test_trapping_constraints():
+    # x, y, x^2, xy, y^2
+    constraint_rhs, constraint_lhs = _make_constraints(2)
+    stable_coefs = np.array([[0, 0, 0, 1, -1], [0, 0, -1, 1, 0]])
+    result = np.tensordot(constraint_lhs, stable_coefs, ((1, 2), (1, 0)))
+    np.testing.assert_array_equal(constraint_rhs, result)
+
+    # xy, xz, yz
+    stable_coefs = np.array([[0, 0, -1], [0, 0.5, 0], [0.5, 0, 0]])
+    mixed_terms = {frozenset((0, 1)): 0, frozenset((0, 2)): 1, frozenset((1, 2)): 2}
+    constraint_lhs = _antisymm_triple_constraints(3, 3, mixed_terms)
+    result = np.tensordot(constraint_lhs, stable_coefs, ((1, 2), (1, 0)))
+    assert result[0] == 0

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -1133,13 +1133,18 @@ def test_remove_and_decrement():
     np.testing.assert_array_equal(expected, result)
 
 
-def test_trapping_constraints():
+@pytest.mark.parametrize("include_bias", (True, False))
+def test_trapping_constraints(include_bias):
     # x, y, x^2, xy, y^2
-    constraint_rhs, constraint_lhs = _make_constraints(2, include_bias=False)
+    constraint_rhs, constraint_lhs = _make_constraints(2, include_bias=include_bias)
     stable_coefs = np.array([[0, 0, 0, 1, -1], [0, 0, -1, 1, 0]])
+    if include_bias:
+        stable_coefs = np.concatenate(([[0], [0]], stable_coefs), axis=1)
     result = np.tensordot(constraint_lhs, stable_coefs, ((1, 2), (1, 0)))
     np.testing.assert_array_equal(constraint_rhs, result)
 
+
+def test_trapping_mixed_only():
     # xy, xz, yz
     stable_coefs = np.array([[0, 0, -1], [0, 0.5, 0], [0.5, 0, 0]])
     mixed_terms = {frozenset((0, 1)): 0, frozenset((0, 2)): 1, frozenset((1, 2)): 2}


### PR DESCRIPTION
I wanted to share this work as a draft that adds `_make_constraints()` from example 8 to `trapping_sr3.py`.  All the differences are noted in the commit messages, but the big ones are:
* Term ordering is controlled by `PolynomialLibrary.powers_`.
* Creates constraints in a 3D numpy array, rather than 2D.  Caller can flatten to either "target" or "feature" constraint order.
IMO this makes the logic a lot clearer, since the term in $Q_{ijk}$ is explicit.  i.e. there's no more long stride calculations like
`n_tgts * (n_tgts + k - 1) + i + n_tgts * int(j * (2 * n_tgts - j - 3) / 2.0)`. 


Also a draft because I enabled too many `PolynomialLibrary` options.  `include_interaction=False` would be incompatible with the trapping constraints IIUC.  OTOH, connecting to `powers_` gives us `include_bias=True` and `interaction_only=True` constraints for free.