### PR TITLE
feat(optimizers): Enable pickling of MIOSR optimizer

### DIFF
--- a/pysindy/optimizers/miosr.py
+++ b/pysindy/optimizers/miosr.py
@@ -268,3 +268,12 @@ class MIOSR(BaseOptimizer):
     def complexity(self):
         check_is_fitted(self)
         return np.count_nonzero(self.coef_)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["model"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.model = None

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -1,6 +1,8 @@
 """
 Unit tests for optimizers.
 """
+import pickle
+
 import numpy as np
 import pytest
 from numpy.linalg import norm
@@ -1129,3 +1131,13 @@ def test_remove_and_decrement():
         existing_vals=existing_vals, vals_to_remove=vals_to_remove
     )
     np.testing.assert_array_equal(expected, result)
+
+
+def test_pickle(data_lorenz):
+    x, t = data_lorenz
+    y = PolynomialLibrary(degree=2).fit_transform(x)
+    opt = MIOSR(target_sparsity=7).fit(x, y)
+    expected = opt.coef_
+    new_opt = pickle.loads(pickle.dumps(opt))
+    result = new_opt.coef_
+    np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
Provides a reference implementation of option 3 in #456 .  At the time, I didn't know about `__setstate__` and `__getstate__`, but these are simpler and more straightforwards than `__reduce__`.

Test fails on master, passes on this branch.

Most of this change is from the example [here.](https://docs.python.org/3/library/pickle.html#handling-stateful-objects)