### PR TITLE
Add notebook review workflow

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,4 +1,10 @@
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   paper:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,11 +1,7 @@
 on:
-  push:
-    branches:
-      - notebooks-review
-  # Uncomment in actual merge
-  # schedule:
-  #   # run twice a month during times when hopefully few other jobs are scheduled
-  #   - cron: '0 12 5,20 * *'
+  schedule:
+    # run twice a month during times when hopefully few other jobs are scheduled
+    - cron: '0 12 6,21 * *'
 
 jobs:
   find-notebooks:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -21,8 +21,21 @@ jobs:
           ref: ${{ github.ref }}
           path: "examples"
           ext: ".ipynb"
+
+  setup-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          pip install .[cvxpy,miosr] sympy
+
   run-notebooks:
-    needs: find-notebooks
+    needs: [find-notebooks,setup-python]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - notebooks-review
+  # Uncomment in actual merge
+  # schedule:
+  #   # run twice a month during times when hopefully few other jobs are scheduled
+  #   - cron: '0 12 5,20 * *'
+
+jobs:
+  find-notebooks:
+    runs-on: ubuntu-latest
+    outputs:
+      paths: ${{ steps.find-notebooks.outputs.paths }}
+    steps:
+      - name: List Files
+        id: find-notebooks
+        uses: mirko-felice/list-files-action@v3.0.5
+        with:
+          repo: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          path: "examples"
+          ext: ".ipynb"
+  run-notebooks:
+    needs: find-notebooks
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        files: ${{ fromJson(needs.find-notebooks.outputs.paths) }}
+    steps:
+      - name: output results
+        run: |
+          echo ${{ matrix.files }}

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -22,8 +22,13 @@ jobs:
           path: "examples"
           ext: ".ipynb"
 
-  setup-python:
+  run-notebooks:
+    needs: find-notebooks
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        files: ${{ fromJson(needs.find-notebooks.outputs.paths) }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -32,16 +37,7 @@ jobs:
           python-version: "3.9"
       - name: Install dependencies
         run: |
-          pip install .[cvxpy,miosr] sympy
-
-  run-notebooks:
-    needs: [find-notebooks,setup-python]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        files: ${{ fromJson(needs.find-notebooks.outputs.paths) }}
-    steps:
-      - name: output results
+          pip install .[cvxpy,miosr] sympy nbconvert jupyter matplotlib seaborn pandas dysts
+      - name: Run Notebook
         run: |
-          echo ${{ matrix.files }}
+          jupyter nbconvert --execute --to notebook  --inplace ${{ matrix.files }}


### PR DESCRIPTION
Twice per month, run all notebooks in the background.  Part 1 of my response to #461.  Part 2 will be a template repo that gets built as part of the pysindy docs lives outside of pysindy and has its own CI, as a venue for migration.

These tests will help us fix easy notebook issues in the interim and prioritize moving notebooks off of this repo.

I'm going to merge this now, because the last commit switched the notebook job to `on: schedule`, which only runs on master, and can only be tested by merging.

I also disabled the draft-pdf workflow for non-master branches.  It still applies in PR, however.  LMK if that's not desired.