### PR TITLE
Check notebook scripts (example.py) in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         cd ..
     - name: Test with pytest
       run: |
-        coverage run --source=pysindy -m pytest test -m "not slow"  && coverage xml
+        coverage run --source=pysindy -m pytest test -m "notebooks or not notebooks"  && coverage xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
I must have messed this up when I added the notebook marker in pytest. 