### PR TITLE
BLD: Limit CVXPY version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ miosr = [
     "gurobipy>=9.5.1,!=10.0.0"
 ]
 cvxpy = [
-    "cvxpy",
+    "cvxpy<1.5",
     "scs>=2.1, !=2.1.4"
 ]
 sbr = [


### PR DESCRIPTION
CVXPY has historically used ECOS, but recently switched to a new solver clarabel.  This causes certain failures due to different arguments (max_iter vs max_iters)