### PR TITLE
BLD: Fix broken versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ cvxpy = [
 sbr = [
     "numpyro",
     "jax",
-    "arviz>=0.18"
+    "arviz==0.17.1",
+    "scipy<1.13.0"
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 readme = "README.rst"
 dependencies = [
-    "scikit-learn>=1.1",
+    "scikit-learn>=1.1, !=1.5.0",
     "derivative>=0.5.4",
 ]
 
@@ -64,7 +64,7 @@ cvxpy = [
 sbr = [
     "numpyro",
     "jax",
-    "arviz"
+    "arviz>=0.18"
 ]
 
 [tool.black]


### PR DESCRIPTION
Arviz uses scipy.signal.gaussian, which was removed in 1.13.  Most recent arviz uses scipy.signal.windows.gaussian

scikit-learn 1.5.0 contained a regression
(https://github.com/scikit-learn/scikit-learn/pull/28352) that has been fixed in
https://github.com/scikit-learn/scikit-learn/pull/29078