### PR TITLE
BUG: #414 remove user warning suppression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,7 @@ force-exclude = '''
 
 [tool.pytest.ini_options]
 filterwarnings = [
-  "ignore::RuntimeWarning",
-  "ignore::UserWarning",]
+  "ignore::RuntimeWarning",]
 addopts = '-m "not slow and not notebooks"'
 markers = ["slow", "notebooks"]
 

--- a/pysindy/__init__.py
+++ b/pysindy/__init__.py
@@ -1,9 +1,8 @@
-from pkg_resources import DistributionNotFound
-from pkg_resources import get_distribution
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     pass
 
 from . import differentiation

--- a/pysindy/__init__.py
+++ b/pysindy/__init__.py
@@ -1,4 +1,5 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
 
 try:
     __version__ = version(__name__)

--- a/pysindy/optimizers/sr3.py
+++ b/pysindy/optimizers/sr3.py
@@ -10,8 +10,6 @@ from ..utils import get_prox
 from ..utils import get_regularization
 from .base import BaseOptimizer
 
-warnings.filterwarnings("ignore", category=UserWarning)
-
 
 class SR3(BaseOptimizer):
     """


### PR DESCRIPTION
Fix #414, remove user warning suppression from pysindy.
The side effect of this PR is the number of warnings in the test files will increase from 139 to 533.
Most warnings are from `StableLinearSR3` and `TrappingSR3` optimizers throwing warnings if given default parameters.
