### PR TITLE
DOC: bump RTD version to allow compatible packages

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.11"
 
 python:
   install:


### PR DESCRIPTION
Some recent bugfixes require `derivative>=0.6.2`, which is marked as 3.9+

So RTFD needs at least 3.9.  I gave it an extra couple years