### PR TITLE
CLN: Ignore notebooks in GH language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 .git_archival.txt  export-subst
 
 # Interpret Jupyter notebooks as Python
-*.ipynb linguist-language=Python
+*.ipynb linguist-vendored
 
 *.ipynb	diff=jupyternotebook
 


### PR DESCRIPTION
Since notebooks now shadow existing code, they (over)duplicate line change statistics.