### PR TITLE
CLN: Ignore notebooks in code count

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 .git_archival.txt  export-subst
 
 # Interpret Jupyter notebooks as Python
-*.ipynb linguist-language=Python
+*.ipynb linguist-vendored
 
 *.ipynb	diff=jupyternotebook
 


### PR DESCRIPTION
Since notebooks now copy existing code, there's no point in counting them in the language stats at all.