### PR TITLE
Fix ssr

### DIFF
--- a/pysindy/optimizers/ssr.py
+++ b/pysindy/optimizers/ssr.py
@@ -194,6 +194,7 @@ class SSR(BaseOptimizer):
                 " ... {: >10} ... {: >10}".format(*row)
             )
 
+        self.history_ = []
         self.err_history_ = []
         for k in range(self.max_iter):
             for i in range(n_targets):

--- a/pysindy/optimizers/ssr.py
+++ b/pysindy/optimizers/ssr.py
@@ -194,8 +194,10 @@ class SSR(BaseOptimizer):
                 " ... {: >10} ... {: >10}".format(*row)
             )
 
-        self.history_ = []
-        self.err_history_ = []
+        self.history_ = [coef]
+        self.err_history_ = [
+            np.sum((y - x @ coef.T) ** 2) + l0_penalty * np.count_nonzero(coef)
+        ]
         for k in range(self.max_iter):
             for i in range(n_targets):
                 if self.criteria == "coefficient_value":

--- a/pysindy/optimizers/ssr.py
+++ b/pysindy/optimizers/ssr.py
@@ -227,5 +227,9 @@ class SSR(BaseOptimizer):
             if np.all(np.sum(np.asarray(inds, dtype=int), axis=1) <= 1):
                 # each equation has one last term
                 break
-        err_min = np.argmin(self.err_history_)
-        self.coef_ = np.asarray(self.history_)[err_min, :, :]
+
+        # err history is reverse of ordering in paper
+        self.err_history_ = self.err_history_[::-1]
+        err_ratio = np.array(self.err_history_[:-1]) / np.array(self.err_history_[1:])
+        ind_err_inflection = np.argmax(err_ratio) + 1
+        self.coef_ = np.asarray(self.history_)[ind_err_inflection, :, :]

--- a/test/test_optimizers/test_optimizers.py
+++ b/test/test_optimizers/test_optimizers.py
@@ -35,6 +35,7 @@ from pysindy.optimizers import StableLinearSR3
 from pysindy.optimizers import STLSQ
 from pysindy.optimizers import TrappingSR3
 from pysindy.optimizers import WrappedOptimizer
+from pysindy.optimizers.ssr import _ind_inflection
 from pysindy.optimizers.stlsq import _remove_and_decrement
 from pysindy.utils import supports_multiple_targets
 from pysindy.utils.odes import enzyme
@@ -1196,17 +1197,40 @@ def test_pickle(data_lorenz, opt_cls, opt_args):
     np.testing.assert_array_equal(result, expected)
 
 
-def test_ssr_history():
-    x = np.zeros((10, 8))
+@pytest.mark.parametrize("kappa", (None, 0.1), ids=["inflection", "L0"])
+def test_ssr_history_selection(kappa):
     rng = np.random.default_rng(1)
-    real_cols = rng.normal(scale=3, size=(10, 4))
-    x[:, :4] = real_cols
-    expected = np.array([[1, 1, 1, 1, 0, 0, 0, 0]])
+    x = rng.normal(size=(30, 8))
+    expected = np.array([[1, 1, 1, 0, 0, 0, 0, 0]])
     y = x @ expected.T
 
-    x += np.random.normal(size=(10, 8), scale=1e-2)
-    opt = SSR()
+    x += np.random.normal(size=(30, 8), scale=1e-2)
+    opt = SSR(kappa=kappa)
     result = opt.fit(x, y).coef_
 
     assert len(opt.history_) == len(opt.err_history_)
     np.testing.assert_allclose(result, expected, atol=1e-2)
+    np.testing.assert_array_equal(result == 0, expected == 0)
+
+
+@pytest.mark.parametrize(
+    ["errs", "expected"],
+    (([3, 1, 0.9], 1), ([1, 0, 0], 1)),
+    ids=["basic", "zero-error"],
+)
+def test_ssr_inflection(errs, expected):
+    result = _ind_inflection(errs)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ["errs", "expected", "message"],
+    (
+        ([1], ValueError, "single point"),
+        ([-1, 1, 1], ValueError, ""),
+    ),
+    ids=["length-1", "negative"],
+)
+def test_ssr_inflection_bad_args(errs, expected, message):
+    with pytest.raises(expected, match=message):
+        _ind_inflection(errs)

--- a/test/test_optimizers/test_optimizers.py
+++ b/test/test_optimizers/test_optimizers.py
@@ -79,6 +79,8 @@ def _align_optimizer_and_1dfeatures(
     if isinstance(opt, TrappingSR3):
         opt = TrappingSR3(_n_tgts=1, _include_bias=False)
         features = np.hstack([features, features])
+    elif isinstance(opt, SSR):
+        features = np.hstack([features, features])
     else:
         features = features
     return opt, features

--- a/test/test_optimizers/test_optimizers.py
+++ b/test/test_optimizers/test_optimizers.py
@@ -1197,13 +1197,16 @@ def test_pickle(data_lorenz, opt_cls, opt_args):
 
 
 def test_ssr_history():
-    x = np.zeros((10, 3))
-    y = np.ones((10,))
-    x[:, 0] = y
-    x += np.random.normal(size=(10, 3), scale=1e-2)
+    x = np.zeros((10, 8))
+    rng = np.random.default_rng(1)
+    real_cols = rng.normal(scale=3, size=(10, 4))
+    x[:, :4] = real_cols
+    expected = np.array([[1, 1, 1, 1, 0, 0, 0, 0]])
+    y = x @ expected.T
+
+    x += np.random.normal(size=(10, 8), scale=1e-2)
     opt = SSR()
     result = opt.fit(x, y).coef_
-    expected = np.array([[1, 0, 0]])
 
     assert len(opt.history_) == len(opt.err_history_)
-    np.testing.assert_allclose(result, expected)
+    np.testing.assert_allclose(result, expected, atol=1e-2)

--- a/test/test_optimizers/test_optimizers.py
+++ b/test/test_optimizers/test_optimizers.py
@@ -1194,3 +1194,14 @@ def test_pickle(data_lorenz, opt_cls, opt_args):
     new_opt = pickle.loads(pickle.dumps(opt))
     result = new_opt.coef_
     np.testing.assert_array_equal(result, expected)
+
+
+def test_ssr_history():
+    x = np.zeros((10, 3))
+    y = np.ones((10,))
+    x[:, 0] = y
+    x += np.random.normal(size=(10, 3), scale=1e-2)
+    opt = SSR()
+    opt.fit(x, y).coef_
+
+    assert len(opt.history_) == len(opt.err_history_)

--- a/test/test_optimizers/test_optimizers.py
+++ b/test/test_optimizers/test_optimizers.py
@@ -1202,6 +1202,8 @@ def test_ssr_history():
     x[:, 0] = y
     x += np.random.normal(size=(10, 3), scale=1e-2)
     opt = SSR()
-    opt.fit(x, y).coef_
+    result = opt.fit(x, y).coef_
+    expected = np.array([[1, 0, 0]])
 
     assert len(opt.history_) == len(opt.err_history_)
+    np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
Fixes #532. Original SSR implementation only used an l0 penalty which defaulted to 0, meaning the full non-sparse model was always chosen. However, the SSR paper does model selection based upon the "inflection point" of the error history. We implemented the function _ind_inflection which takes as input the error history of the SSR iterations and returns the index at which the inflection occurs, using the metric for inflection described in the SSR paper. This model selection based on error history inflection is the new default when the l0 penalty is 0. The API does not change, but you can note the different results in the unittest `test_ssr_history_selection`.