### PR TITLE
Extract common functionality from `SINDy` to `_BaseSINDy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ readme = "README.rst"
 dependencies = [
     "scikit-learn>=1.1, !=1.5.0",
     "derivative>=0.6.2",
+    "typing_extensions",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 readme = "README.rst"
 dependencies = [
+    "jax>=0.4,<0.5",
     "scikit-learn>=1.1, !=1.5.0",
     "derivative>=0.6.2",
     "typing_extensions",
@@ -64,7 +65,6 @@ cvxpy = [
 ]
 sbr = [
     "numpyro",
-    "jax",
     "arviz==0.17.1",
     "scipy<1.13.0"
 ]

--- a/pysindy/_typing.py
+++ b/pysindy/_typing.py
@@ -4,4 +4,11 @@ import numpy.typing as npt
 # In python 3.12, use type statement
 # https://docs.python.org/3/reference/simple_stmts.html#the-type-statement
 NpFlt = np.floating[npt.NBitBase]
-Float2D = np.ndarray[tuple[int, int], np.dtype[NpFlt]]
+FloatDType = np.dtype[np.floating[npt.NBitBase]]
+Int1D = np.ndarray[tuple[int], np.dtype[np.int_]]
+Float1D = np.ndarray[tuple[int], FloatDType]
+Float2D = np.ndarray[tuple[int, int], FloatDType]
+Float3D = np.ndarray[tuple[int, int, int], FloatDType]
+Float4D = np.ndarray[tuple[int, int, int, int], FloatDType]
+Float5D = np.ndarray[tuple[int, int, int, int, int], FloatDType]
+FloatND = npt.NDArray[NpFlt]

--- a/pysindy/feature_library/__init__.py
+++ b/pysindy/feature_library/__init__.py
@@ -1,3 +1,4 @@
+from .base import BaseFeatureLibrary
 from .base import ConcatLibrary
 from .base import TensoredLibrary
 from .custom_library import CustomLibrary
@@ -11,6 +12,7 @@ from .sindy_pi_library import SINDyPILibrary
 from .weak_pde_library import WeakPDELibrary
 
 __all__ = [
+    "BaseFeatureLibrary",
     "ConcatLibrary",
     "TensoredLibrary",
     "GeneralizedLibrary",

--- a/pysindy/feature_library/__init__.py
+++ b/pysindy/feature_library/__init__.py
@@ -1,4 +1,3 @@
-from .base import BaseFeatureLibrary
 from .base import ConcatLibrary
 from .base import TensoredLibrary
 from .custom_library import CustomLibrary
@@ -12,7 +11,6 @@ from .sindy_pi_library import SINDyPILibrary
 from .weak_pde_library import WeakPDELibrary
 
 __all__ = [
-    "BaseFeatureLibrary",
     "ConcatLibrary",
     "TensoredLibrary",
     "GeneralizedLibrary",

--- a/pysindy/feature_library/base.py
+++ b/pysindy/feature_library/base.py
@@ -8,6 +8,7 @@ from itertools import repeat
 from typing import Optional
 from typing import Sequence
 
+import jax
 import numpy as np
 from scipy import sparse
 from sklearn.base import TransformerMixin
@@ -144,20 +145,28 @@ def x_sequence_or_item(wrapped_func):
     @wraps(wrapped_func)
     def func(self, x, *args, **kwargs):
         if isinstance(x, Sequence):
-            xs = [AxesArray(xi, comprehend_axes(xi)) for xi in x]
+            if isinstance(x[0], jax.Array):
+                xs = x
+            else:
+                xs = [AxesArray(xi, comprehend_axes(xi)) for xi in x]
             result = wrapped_func(self, xs, *args, **kwargs)
             # if transform() is a normal "return x"
             if isinstance(result, Sequence) and isinstance(result[0], np.ndarray):
                 return [AxesArray(xp, comprehend_axes(xp)) for xp in result]
             return result  # e.g. fit() returns self
         else:
-            if not sparse.issparse(x):
+            if isinstance(x, jax.Array):
+
+                def reconstructor(x):
+                    return x
+
+            elif not sparse.issparse(x) and isinstance(x, np.ndarray):
                 x = AxesArray(x, comprehend_axes(x))
 
                 def reconstructor(x):
                     return x
 
-            else:  # sparse arrays
+            else:  # sparse
                 reconstructor = type(x)
                 axes = comprehend_axes(x)
                 wrap_axes(axes, x)

--- a/pysindy/feature_library/base.py
+++ b/pysindy/feature_library/base.py
@@ -146,7 +146,8 @@ def x_sequence_or_item(wrapped_func):
         if isinstance(x, Sequence):
             xs = [AxesArray(xi, comprehend_axes(xi)) for xi in x]
             result = wrapped_func(self, xs, *args, **kwargs)
-            if isinstance(result, Sequence):  # e.g. transform() returns x
+            # if transform() is a normal "return x"
+            if isinstance(result, Sequence) and isinstance(result[0], np.ndarray):
                 return [AxesArray(xp, comprehend_axes(xp)) for xp in result]
             return result  # e.g. fit() returns self
         else:

--- a/pysindy/feature_library/polynomial_library.py
+++ b/pysindy/feature_library/polynomial_library.py
@@ -160,7 +160,7 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
         return feature_names
 
     @x_sequence_or_item
-    def fit(self, x_full, y=None):
+    def fit(self, x_full: list[AxesArray], y=None):
         """
         Compute number of output features.
 

--- a/pysindy/feature_library/polynomial_library.py
+++ b/pysindy/feature_library/polynomial_library.py
@@ -12,6 +12,7 @@ from sklearn.utils.validation import check_is_fitted
 from ..utils import AxesArray
 from ..utils import comprehend_axes
 from ..utils import wrap_axes
+from ..utils._axis_conventions import AX_COORD
 from .base import BaseFeatureLibrary
 from .base import x_sequence_or_item
 
@@ -180,7 +181,7 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
                 "Can't have include_interaction be False and interaction_only"
                 " be True"
             )
-        n_features = x_full[0].shape[x_full[0].ax_coord]
+        n_features = x_full[0].shape[AX_COORD]
         combinations = self._combinations(
             n_features,
             self.degree,
@@ -217,7 +218,7 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
                 axes = comprehend_axes(x)
                 x = x.asformat("csc")
                 wrap_axes(axes, x)
-            n_features = x.shape[x.ax_coord]
+            n_features = x.shape[AX_COORD]
             if n_features != self.n_features_in_:
                 raise ValueError("x shape does not match training shape")
 

--- a/pysindy/optimizers/base.py
+++ b/pysindy/optimizers/base.py
@@ -5,10 +5,10 @@ import abc
 import warnings
 from typing import Callable
 from typing import NewType
+from typing import Optional
 from typing import Tuple
 
 import numpy as np
-from numpy.typing import NBitBase
 from scipy import sparse
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import LinearRegression
@@ -18,10 +18,10 @@ from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.validation import check_X_y
 
 from .._typing import Float2D
+from .._typing import FloatDType
 from ..utils import AxesArray
 from ..utils import drop_nan_samples
 
-AnyFloat = np.dtype[np.floating[NBitBase]]
 NFeat = NewType("NFeat", int)
 NTarget = NewType("NTarget", int)
 
@@ -40,8 +40,8 @@ def _rescale_data(X, y, sample_weight):
 
 
 class _BaseOptimizer(BaseEstimator, abc.ABC):
-    coef_: np.ndarray[tuple[NTarget, NFeat], AnyFloat]
-    intercept_: np.ndarray[tuple[NTarget], AnyFloat]
+    coef_: np.ndarray[tuple[NTarget, NFeat], FloatDType]
+    intercept_: np.ndarray[tuple[NTarget], FloatDType]
 
     @property
     def complexity(self):
@@ -101,7 +101,7 @@ class BaseOptimizer(LinearRegression, _BaseOptimizer):
 
     max_iter: int
     normalize_columns: bool
-    initial_guess: None | np.ndarray[tuple[NTarget, NFeat], AnyFloat]
+    initial_guess: Optional[np.ndarray[tuple[NTarget, NFeat], FloatDType]]
     copy_X: bool
     unbias: bool
 

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -5,32 +5,28 @@ from itertools import product
 from itertools import repeat
 from math import comb
 from typing import cast
-from typing import NewType
 from typing import Optional
 from typing import TypeVar
 from typing import Union
 
 import cvxpy as cp
 import numpy as np
-from numpy.typing import NBitBase
 from numpy.typing import NDArray
 from sklearn.exceptions import ConvergenceWarning
 
+from .._typing import Float1D
+from .._typing import Float2D
+from .._typing import Float3D
+from .._typing import Float4D
+from .._typing import Float5D
+from .._typing import Int1D
 from ..feature_library.polynomial_library import n_poly_features
 from ..feature_library.polynomial_library import PolynomialLibrary
 from ..utils import reorder_constraints
-from .base import AnyFloat
+from .base import FloatDType
 from .base import NFeat
 from .base import NTarget
 from .constrained_sr3 import ConstrainedSR3
-
-Int1D = np.ndarray[tuple[int], np.dtype[np.int_]]
-Float1D = np.ndarray[tuple[int], AnyFloat]
-Float2D = np.ndarray[tuple[int, int], AnyFloat]
-Float3D = np.ndarray[tuple[int, int, int], AnyFloat]
-Float4D = np.ndarray[tuple[int, int, int, int], AnyFloat]
-Float5D = np.ndarray[tuple[int, int, int, int, int], AnyFloat]
-FloatND = NDArray[np.floating[NBitBase]]
 
 
 class EnstrophyMat:
@@ -601,7 +597,7 @@ class TrappingSR3(ConstrainedSR3):
         self,
         trap_ctr: Float1D,
         prev_A: Float2D,
-        coef_sparse: np.ndarray[tuple[NFeat, NTarget], AnyFloat],
+        coef_sparse: np.ndarray[tuple[NFeat, NTarget], FloatDType],
     ) -> tuple[Float1D, Float2D]:
         r"""Updates the trap center
 
@@ -693,7 +689,7 @@ class TrappingSR3(ConstrainedSR3):
             self.constraint_lhs = reorder_constraints(
                 self.constraint_lhs, n_features, output_order="feature"
             )
-        coef_sparse: np.ndarray[tuple[NFeat, NTarget], AnyFloat] = self.coef_.T
+        coef_sparse: np.ndarray[tuple[NFeat, NTarget], FloatDType] = self.coef_.T
 
         # Print initial values for each term in the optimization
         if self.verbose:

--- a/pysindy/optimizers/trapping_sr3.py
+++ b/pysindy/optimizers/trapping_sr3.py
@@ -19,9 +19,11 @@ from sklearn.exceptions import ConvergenceWarning
 from ..feature_library.polynomial_library import n_poly_features
 from ..feature_library.polynomial_library import PolynomialLibrary
 from ..utils import reorder_constraints
+from .base import AnyFloat
+from .base import NFeat
+from .base import NTarget
 from .constrained_sr3 import ConstrainedSR3
 
-AnyFloat = np.dtype[np.floating[NBitBase]]
 Int1D = np.ndarray[tuple[int], np.dtype[np.int_]]
 Float1D = np.ndarray[tuple[int], AnyFloat]
 Float2D = np.ndarray[tuple[int, int], AnyFloat]
@@ -29,8 +31,6 @@ Float3D = np.ndarray[tuple[int, int, int], AnyFloat]
 Float4D = np.ndarray[tuple[int, int, int, int], AnyFloat]
 Float5D = np.ndarray[tuple[int, int, int, int, int], AnyFloat]
 FloatND = NDArray[np.floating[NBitBase]]
-NFeat = NewType("NFeat", int)
-NTarget = NewType("NTarget", int)
 
 
 class EnstrophyMat:

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -20,8 +20,8 @@ from typing_extensions import Self
 
 from .differentiation import BaseDifferentiation
 from .differentiation import FiniteDifference
-from .feature_library import BaseFeatureLibrary
 from .feature_library import PolynomialLibrary
+from .feature_library.base import BaseFeatureLibrary
 
 try:  # Waiting on PEP 690 to lazy import CVXPY
     from .optimizers import SINDyPI

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -46,6 +46,9 @@ class _BaseSINDy(BaseEstimator, ABC):
     discrete_time: bool
     model: Pipeline
     feature_names: Optional[list[str]]
+    # Hacks to remove later
+    discrete_time: bool = False
+    n_control_features_: int = 0
 
     @abstractmethod
     def fit(self, x, t, *args, **kwargs) -> Self:
@@ -107,10 +110,7 @@ class _BaseSINDy(BaseEstimator, ABC):
         """
         eqns = self.equations(precision)
         for name, eqn in zip(self.feature_names, eqns, strict=True):
-            if self.discrete_time:
-                lhs = f"({name})[k+1]"
-            else:
-                lhs = f"({name})'"
+            lhs = f"({name})'"
             print(f"{lhs} = {eqn}", **kwargs)
 
     def get_feature_names(self):

--- a/pysindy/pysindy.py
+++ b/pysindy/pysindy.py
@@ -29,7 +29,9 @@ try:  # Waiting on PEP 690 to lazy import CVXPY
     sindy_pi_flag = True
 except ImportError:
     sindy_pi_flag = False
-from .optimizers import STLSQ, BaseOptimizer
+from .optimizers import STLSQ
+from .optimizers.base import _BaseOptimizer
+from .optimizers.base import BaseOptimizer
 from .utils import AxesArray
 from .utils import comprehend_axes
 from .utils import concat_sample_axis
@@ -43,7 +45,7 @@ from .utils import validate_no_reshape
 class _BaseSINDy(BaseEstimator, ABC):
 
     feature_library: BaseFeatureLibrary
-    optimizer: BaseOptimizer
+    optimizer: _BaseOptimizer
     discrete_time: bool
     model: Pipeline
     feature_names: Optional[list[str]]

--- a/pysindy/utils/__init__.py
+++ b/pysindy/utils/__init__.py
@@ -8,7 +8,6 @@ from .base import drop_nan_samples
 from .base import flatten_2d_tall
 from .base import get_prox
 from .base import get_regularization
-from .base import print_model
 from .base import reorder_constraints
 from .base import supports_multiple_targets
 from .base import validate_control_variables
@@ -56,7 +55,6 @@ __all__ = [
     "drop_nan_samples",
     "get_prox",
     "get_regularization",
-    "print_model",
     "reorder_constraints",
     "supports_multiple_targets",
     "validate_control_variables",

--- a/pysindy/utils/__init__.py
+++ b/pysindy/utils/__init__.py
@@ -5,7 +5,6 @@ from .axes import SampleConcatter
 from .axes import wrap_axes
 from .base import capped_simplex_projection
 from .base import drop_nan_samples
-from .base import equations
 from .base import flatten_2d_tall
 from .base import get_prox
 from .base import get_regularization
@@ -55,7 +54,6 @@ __all__ = [
     "comprehend_axes",
     "capped_simplex_projection",
     "drop_nan_samples",
-    "equations",
     "get_prox",
     "get_regularization",
     "print_model",

--- a/pysindy/utils/_axis_conventions.py
+++ b/pysindy/utils/_axis_conventions.py
@@ -1,0 +1,2 @@
+AX_TIME = -2
+AX_COORD = -1

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -61,7 +61,7 @@ def validate_input(x, t=T_DEFAULT):
     return x_new
 
 
-def validate_no_reshape(x, t=T_DEFAULT):
+def validate_no_reshape(x, t: float | np.ndarray = T_DEFAULT):
     """Check types and numerical sensibility of arguments.
 
     Args:
@@ -72,7 +72,7 @@ def validate_no_reshape(x, t=T_DEFAULT):
         x as 2D array, with time dimension on first axis and coordinate
         index on second axis.
     """
-    if not isinstance(x, np.ndarray):
+    if not hasattr(x, "shape"):
         raise TypeError("Input value must be array-like")
     check_array(x, ensure_2d=False, allow_nd=True)
 
@@ -84,7 +84,7 @@ def validate_no_reshape(x, t=T_DEFAULT):
             if t <= 0:
                 raise ValueError("t must be positive")
         # Only apply these tests if t is array-like
-        elif isinstance(t, np.ndarray):
+        elif hasattr(t, "shape"):
             if not len(t) == x.shape[-2]:
                 raise ValueError("Length of t should match x.shape[-2].")
             if not np.all(t[:-1] < t[1:]):

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -289,25 +289,6 @@ def capped_simplex_projection(trimming_array, trimming_fraction):
     return np.maximum(np.minimum(trimming_array - x, 1.0), 0.0)
 
 
-def print_model(
-    coef,
-    input_features,
-    precision=3,
-):
-    def term(c, name):
-        rounded_coef = np.round(c, precision)
-        if rounded_coef == 0:
-            return ""
-        else:
-            return f"{c:.{precision}f} {name}"
-
-    components = [term(c, i) for c, i in zip(coef, input_features)]
-    eq = " + ".join(filter(bool, components))
-    if not eq:
-        eq = f"{0:.{precision}f}"
-    return eq
-
-
 def supports_multiple_targets(estimator):
     """Checks whether estimator supports multiple targets."""
     if isinstance(estimator, MultiOutputMixin):

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -1,5 +1,4 @@
 import warnings
-from itertools import repeat
 from typing import Callable
 from typing import Sequence
 from typing import Union
@@ -293,64 +292,20 @@ def capped_simplex_projection(trimming_array, trimming_fraction):
 def print_model(
     coef,
     input_features,
-    errors=None,
-    intercept=None,
-    error_intercept=None,
     precision=3,
-    pm="±",
 ):
-    """
-    Args:
-        coef:
-        input_features:
-        errors:
-        intercept:
-        sigma_intercept:
-        precision:
-        pm:
-    Returns:
-    """
-
-    def term(c, sigma, name):
+    def term(c, name):
         rounded_coef = np.round(c, precision)
-        if rounded_coef == 0 and sigma is None:
-            return ""
-        elif sigma is None:
-            return f"{c:.{precision}f} {name}"
-        elif rounded_coef == 0 and np.round(sigma, precision) == 0:
+        if rounded_coef == 0:
             return ""
         else:
-            return f"({c:.{precision}f} {pm} {sigma:.{precision}f}) {name}"
+            return f"{c:.{precision}f} {name}"
 
-    errors = errors if errors is not None else repeat(None)
-    components = [term(c, e, i) for c, e, i in zip(coef, errors, input_features)]
+    components = [term(c, i) for c, i in zip(coef, input_features)]
     eq = " + ".join(filter(bool, components))
-
-    if not eq or intercept or error_intercept is not None:
-        intercept = intercept or 0
-        intercept_str = term(intercept, error_intercept, "").strip()
-        if eq and intercept_str:
-            eq += " + "
-            eq += intercept_str
-        elif not eq:
-            eq = f"{intercept:.{precision}f}"
+    if not eq:
+        eq = f"{0:.{precision}f}"
     return eq
-
-
-def equations(pipeline, input_features=None, precision=3, input_fmt=None):
-    input_features = pipeline.steps[0][1].get_feature_names(input_features)
-    if input_fmt:
-        input_features = [input_fmt(i) for i in input_features]
-    coef = pipeline.steps[-1][1].coef_
-    intercept = pipeline.steps[-1][1].intercept_
-    if np.isscalar(intercept):
-        intercept = intercept * np.ones(coef.shape[0])
-    return [
-        print_model(
-            coef[i], input_features, intercept=intercept[i], precision=precision
-        )
-        for i in range(coef.shape[0])
-    ]
 
 
 def supports_multiple_targets(estimator):

--- a/pysindy/utils/base.py
+++ b/pysindy/utils/base.py
@@ -61,7 +61,7 @@ def validate_input(x, t=T_DEFAULT):
     return x_new
 
 
-def validate_no_reshape(x, t: float | np.ndarray = T_DEFAULT):
+def validate_no_reshape(x, t: Union[float, np.ndarray, object] = T_DEFAULT):
     """Check types and numerical sensibility of arguments.
 
     Args:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@ Shared pytest fixtures for unit tests.
 """
 from pathlib import Path
 
+import jax
 import numpy as np
 import pytest
 from scipy.integrate import solve_ivp
@@ -19,6 +20,8 @@ from pysindy.utils.odes import logistic_map_control
 from pysindy.utils.odes import logistic_map_multicontrol
 from pysindy.utils.odes import lorenz
 from pysindy.utils.odes import lorenz_control
+
+jax.config.update("jax_platform_name", "cpu")
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Begin #351

This pull request begins the abstraction of the `SINDy` class, which handles a lot of methods with special cases, to a variety of classes that reflect fundamental differences between problem formulations.  Here, I pull out `_BaseSINDy`, which contains basic information about the feature library, system dimension, and printing the equations.

Future PRs will make Weak and discrete their own classes, modify feature libraries to be amenable to jax, numpy, and cvxpy arrays, and introduce the Single-Step SINDy class and associated optimizer/problem setup.