### PR TITLE
Speed up SBR tests, and add NUTS kwargs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
         pip install .[dev,miosr,cvxpy,sbr]
     - name: Test with pytest
       run: |
-        coverage run --source=pysindy -m pytest test -m "not slow"  && coverage xml
+        coverage run --source=pysindy -m pytest test -m "notebooks or not notebooks"  && coverage xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
         pip install .[dev,miosr,cvxpy,sbr]
     - name: Test with pytest
       run: |
-        coverage run --source=pysindy -m pytest test -m "notebooks or not notebooks"  && coverage xml
+        coverage run --source=pysindy -m pytest test -m "not slow"  && coverage xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/pysindy/_typing.py
+++ b/pysindy/_typing.py
@@ -1,0 +1,7 @@
+import numpy as np
+import numpy.typing as npt
+
+# In python 3.12, use type statement
+# https://docs.python.org/3/reference/simple_stmts.html#the-type-statement
+NpFlt = np.floating[npt.NBitBase]
+Float2D = np.ndarray[tuple[int, int], np.dtype[NpFlt]]

--- a/pysindy/optimizers/base.py
+++ b/pysindy/optimizers/base.py
@@ -14,6 +14,7 @@ from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.validation import check_X_y
 
+from .._typing import Float2D
 from ..utils import AxesArray
 from ..utils import drop_nan_samples
 
@@ -178,8 +179,7 @@ class BaseOptimizer(LinearRegression, ComplexityMixin):
 
         x_normed = np.copy(x)
         if self.normalize_columns:
-            reg = 1 / np.linalg.norm(x, 2, axis=0)
-            x_normed = x * reg
+            feat_norms, x_normed = _normalize_features(x_normed)
 
         if self.initial_guess is None:
             self.coef_ = np.linalg.lstsq(x_normed, y, rcond=None)[0].T
@@ -203,11 +203,11 @@ class BaseOptimizer(LinearRegression, ComplexityMixin):
 
         # Rescale coefficients to original units
         if self.normalize_columns:
-            self.coef_ = np.multiply(reg, self.coef_)
+            self.coef_ = self.coef_ / feat_norms
             if hasattr(self, "coef_full_"):
-                self.coef_full_ = np.multiply(reg, self.coef_full_)
+                self.coef_full_ = self.coef_full_ / feat_norms
             for i in range(np.shape(self.history_)[0]):
-                self.history_[i] = np.multiply(reg, self.history_[i])
+                self.history_[i] = self.history_[i] / feat_norms
 
         self._set_intercept(X_offset, y_offset, X_scale)
         return self
@@ -395,3 +395,9 @@ def _drop_random_samples(
     x_dot_new = np.take(x_dot, rand_inds, axis=x.ax_sample)
 
     return x_new, x_dot_new
+
+
+def _normalize_features(x: Float2D) -> Float2D:
+    "Calculate the length of vectors and normalize them"
+    lengths = np.linalg.norm(x, 2, axis=0)
+    return lengths, x / lengths

--- a/test/test_optimizers/test_optimizers.py
+++ b/test/test_optimizers/test_optimizers.py
@@ -126,7 +126,7 @@ def data(request):
         ElasticNet(fit_intercept=False),
         DummyLinearModel(),
         MIOSR(),
-        SBR(),
+        SBR(num_warmup=10, num_samples=10),
     ],
     ids=lambda param: type(param),
 )

--- a/test/test_optimizers/test_optimizers.py
+++ b/test/test_optimizers/test_optimizers.py
@@ -154,7 +154,19 @@ def test_not_fitted(optimizer):
         optimizer.predict(np.ones((1, 3)))
 
 
-@pytest.mark.parametrize("optimizer", [STLSQ(), SR3(), SBR()])
+@pytest.mark.parametrize(
+    "optimizer",
+    [
+        STLSQ(),
+        SR3(),
+        SBR(
+            num_warmup=1,
+            num_samples=1,
+            nuts_kwargs={"max_tree_depth": 1, "target_accept_prob": 0.1},
+        ),
+    ],
+    ids=type,
+)
 def test_complexity_not_fitted(optimizer, data_derivative_2d):
     with pytest.raises(NotFittedError):
         optimizer.complexity


### PR DESCRIPTION
This PR implements some changes to testing:
1) Tests involving SBR use a much smaller `num_warmup`, `num_samples` than the default arguments.
2) nuts_kwargs added to allow fine control of the sampler (to allow faster termination in tests)
3) column normalization is extracted from BaseOptimizer.fit so that it can be tested independently.  The test no longer is parametrized across all subclasses, but rather just tests the helper function.
4) Do a few more notebook tests in CI.