### PR TITLE
SINDyPI was added to init. It is not recognizable otherwise

### DIFF
--- a/pysindy/__init__.py
+++ b/pysindy/__init__.py
@@ -36,6 +36,7 @@ from .optimizers import SR3
 from .optimizers import SSR
 from .optimizers import STLSQ
 from .optimizers import EnsembleOptimizer
+from .optimizers import SINDyPI
 
 try:
     from .optimizers import ConstrainedSR3

--- a/pysindy/optimizers/__init__.py
+++ b/pysindy/optimizers/__init__.py
@@ -4,6 +4,7 @@ from .frols import FROLS
 from .sr3 import SR3
 from .ssr import SSR
 from .stlsq import STLSQ
+from .sindy_pi import SINDyPI
 from .wrapped_optimizer import WrappedOptimizer
 
 try:


### PR DESCRIPTION
SINDyPI is not recognizable by following the documenations. I added it to both the __init__ file of the optimizer.py and _init__.py