### PR TITLE
Pickle SR3 and subordinate classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     hooks:
     -   id: end-of-file-fixer
         exclude: (.txt|^docs/JOSS1|^docs/JOSS2|^examples/data/)
-        stages: [commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite]
+        stages: [pre-commit, pre-merge-commit, pre-push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite]
     -   id: trailing-whitespace
-        stages: [commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite]
+        stages: [pre-commit, pre-merge-commit, pre-push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite]
         exclude: (.txt|^docs/JOSS1|^docs/JOSS2|^examples/data/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 readme = "README.rst"
 dependencies = [
     "jax>=0.4,<0.5",
-    "scikit-learn>=1.1, !=1.5.0",
+    "scikit-learn>=1.1, !=1.5.0, !=1.6.0",
     "derivative>=0.6.2",
     "typing_extensions",
 ]

--- a/test/test_optimizers/debug.py
+++ b/test/test_optimizers/debug.py
@@ -1,0 +1,20 @@
+import pickle
+from functools import wraps
+
+
+def foo(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        print(f"Called {func}")
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@foo
+def bar(a, b):
+    print(a + b)
+
+
+bars = pickle.dumps(bar)
+barl = pickle.loads(bars)

--- a/test/test_optimizers/test_optimizers.py
+++ b/test/test_optimizers/test_optimizers.py
@@ -1183,12 +1183,14 @@ def test_remove_and_decrement():
     (
         (MIOSR, {"target_sparsity": 7}),
         (SBR, {"num_warmup": 10, "num_samples": 10}),
+        (SR3, {}),
+        (TrappingSR3, {"_n_tgts": 3, "_include_bias": True}),
     ),
 )
 def test_pickle(data_lorenz, opt_cls, opt_args):
     x, t = data_lorenz
     y = PolynomialLibrary(degree=2).fit_transform(x)
-    opt = opt_cls(**opt_args).fit(x, y)
+    opt = opt_cls(**opt_args).fit(y, x)
     expected = opt.coef_
     new_opt = pickle.loads(pickle.dumps(opt))
     result = new_opt.coef_

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -101,17 +101,9 @@ def test_get_prox_and_regularization_bad_shape(regularization, lam):
         prox(data, lam)
 
 
-@pytest.mark.parametrize(
-    "regularization", ["weighted_l0", "weighted_l1", "weighted_l2"]
-)
-@pytest.mark.parametrize(
-    "lam",
-    [
-        np.array([[1, 2]]),
-        1,
-    ],
-)
-def test_get_weighted_prox_and_regularization_bad_shape(regularization, lam):
+@pytest.mark.parametrize("regularization", ["l0", "l1", "l2"])
+def test_get_weighted_prox_and_regularization_bad_shape(regularization):
+    lam = np.array([[1, 2]])
     data = np.array([[-2, 5]]).T
     reg = get_regularization(regularization)
     with pytest.raises(ValueError):


### PR DESCRIPTION
This change moves us away from specifically requiring "weighted" in specifying SR3 regularizer.  Previously, much of the weighted functionality had been combined with the unweighted (scalar-weighted) functionality, and all that remained was guard checks for the shape of the weight and data.  However, that guard code was added at runtime, making the functions unpickleable (See [pickle docs][pickledoc]).  Some of the solution was to use [`@wraps`][wraps].  The rest required that we add guard code in a way that was determined at import time, rather than runtime.  See commit messages from this PR.

Also includes two quick fixes for a broken scikit-learn version and updating our pre-commit format.

[pickledoc]: https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled
[wraps]: https://docs.python.org/3/library/functools.html#functools.wraps