### PR TITLE
BLD: Limit numpy to <2.0

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -20,7 +20,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: docs/JOSS2/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ readme = "README.rst"
 dependencies = [
     "jax>=0.4,<0.5",
     "scikit-learn>=1.1, !=1.5.0",
+    "numpy<2.0",
     "derivative>=0.6.2",
     "typing_extensions",
 ]


### PR DESCRIPTION
Future work will be needed to update dependency info for, e.g. compatibility with scikit-learn and cvxpy