### PR TITLE
CI: Bump version of publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build package
         run: python -m build .
       - name: Upload package
-        uses: pypa/gh-action-pypi-publish@v1.8.5
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
[Action](https://github.com/Jacob-Stevens-Haas/mitosis/actions/runs/14026712826/job/39266594107) has failure:
```
Checking dist/pysindy-2.0.0rc2-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2.                                                         
```
This is due to an out-of-date twine dependency in the old version of the github action.

This commit bumps the version of the pypi publish action