### PR TITLE
Fix default n_subset based on replace flag (bootstrap logic)

### DIFF
--- a/pysindy/optimizers/base.py
+++ b/pysindy/optimizers/base.py
@@ -273,7 +273,11 @@ class EnsembleOptimizer(BaseOptimizer):
         Number of models to generate via ensemble
 
     n_subset : int, optional (default len(time base))
-        Number of time points to use for ensemble
+        Number of time points to use for ensemble.
+        When bagging with replacement (bootstrap), a value equal to the 
+        original number of samples is standard.
+        See: B. Efron (1979), "Bootstrap Methods: Another Look at the 
+        Jackknife", The Annals of Statistics.
 
     n_candidates_to_drop : int, optional (default 1)
         Number of candidate terms in the feature library to drop during

--- a/pysindy/optimizers/base.py
+++ b/pysindy/optimizers/base.py
@@ -351,7 +351,10 @@ class EnsembleOptimizer(BaseOptimizer):
         x = AxesArray(np.asarray(x), {"ax_sample": 0, "ax_coord": 1})
         n_samples = x.shape[x.ax_sample]
         if self.bagging and self.n_subset is None:
-            self.n_subset = int(0.6 * n_samples)
+            if self.replace:
+                self.n_subset = n_samples
+            else:
+                self.n_subset = int(0.6 * n_samples)
         if self.bagging and self.n_subset > n_samples and not self.replace:
             warnings.warn(
                 "n_subset is larger than sample count without replacement; cannot bag."

--- a/pysindy/optimizers/base.py
+++ b/pysindy/optimizers/base.py
@@ -274,9 +274,9 @@ class EnsembleOptimizer(BaseOptimizer):
 
     n_subset : int, optional (default len(time base))
         Number of time points to use for ensemble.
-        When bagging with replacement (bootstrap), a value equal to the 
+        When bagging with replacement (bootstrap), a value equal to the
         original number of samples is standard.
-        See: B. Efron (1979), "Bootstrap Methods: Another Look at the 
+        See: B. Efron (1979), "Bootstrap Methods: Another Look at the
         Jackknife", The Annals of Statistics.
 
     n_candidates_to_drop : int, optional (default 1)


### PR DESCRIPTION
This PR updates the default value of `n_subset` in `EnsembleOptimizer` to respect the bootstrap sampling convention when `replace=True`.

This change aligns the implementation with both the docstring and classical bootstrap theory (Efron, 1979), as discussed in [Issue #617](https://github.com/dynamicslab/pysindy/issues/617).